### PR TITLE
Iterable Map

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,11 @@
 version = 3.0.0-RC6
 runner.dialect = scala3
 
-style = defaultWithAlign # For pretty alignment.
+style = default
 maxColumn = 120          # For my wide 30" display.
 includeCurlyBraceInSelectChains = false
 newlines.penalizeSingleSelectMultiArgList = false
 project.git = true
 project.excludeFilters = ["target/"]
 docstrings.style = Asterisk
+indent.main = 2

--- a/process/sprint1.csv
+++ b/process/sprint1.csv
@@ -1,4 +1,4 @@
-Sprint 1 (da 09/08/2021-  a 15/08/2021 )
+Sprint 1 (da 09/08/2021 a 15/08/2021),,,,,,,,,,,
 Product Backlog Item,Sprint Task,URL,Volunteer,Initial estimate of effort,1,2,3,4,5,6,7
 Setting up the build environment,Create project repository,,Nicolas Farabegoli,1,0,,,,,,
 ,Create sbt project,,Nicolas Farabegoli,2,0,,,,,,

--- a/process/sprint2.csv
+++ b/process/sprint2.csv
@@ -1,6 +1,6 @@
-Sprint 2 (da 15/08/2021-  a 22/08/2021 ),,,,,,,,,,,
+Sprint 2 (da 15/08/2021 a 22/08/2021),,,,,,,,,,,
 Product Backlog Item,Sprint Task,URL,Volunteer,Initial estimate of effort,1,2,3,4,5,6,7
-As a framework user I want to create a World,"Define a Sparse Set data structure ",,"Nicolas Farabegoli, Nicolò Di Domenico",10,8,,,,,,
+As a framework user I want to create a World,"Define a Sparse Set data structure ",,"Nicolas Farabegoli, Nicolò Di Domenico",10,8,8,2,0,,,
 ,Define the World type,,Nicolas Farabegoli,2,0,,,,,,
 ,Design detailed World's architecture,,"Nicolas Farabegoli, Linda Vitali, Nicolò Di Domenico, Giacomo Cavalieri",8,0,,,,,,
 As a framework user I want to manipulate the  World's Entities,Define Entities type,,Nicolas Farabegoli,2,0,,,,,,

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,6 +1,0 @@
-@main def hello: Unit = {
-  println("Hello world!")
-  println(msg)
-}
-
-def msg = "I was compiled by Scala 3. :)"

--- a/src/main/scala/dev/atedeg/ecscala/util/BaseIterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/BaseIterableMap.scala
@@ -1,10 +1,49 @@
 package dev.atedeg.ecscala.util
 
-import scala.collection.Map
-import scala.collection.mutable
+import scala.collection.*
+import scala.collection.mutable.ReusableBuilder
+import scala.collection.generic.DefaultSerializable
+
+trait IterableMap[K, +V]
+    extends Map[K, V]
+    with MapOps[K, V, IterableMap, IterableMap[K, V]]
+    with MapFactoryDefaults[K, V, IterableMap, Iterable] {
+  override def mapFactory: MapFactory[IterableMap] = IterableMap
+}
+
+private[util] abstract class BaseIterableMap[K, V](elems: (K, V)*) extends IterableMap[K, V] {
+
+  protected type Dense[T] <: IndexedSeq[T] with SeqOps[T, IndexedSeq, IndexedSeq[T]]
+  protected type Sparse[K, V] <: Map[K, V]
+
+  protected def denseFactory: SeqFactory[Dense]
+  protected def sparseFactory: MapFactory[Sparse]
+
+  protected val denseKeys: Dense[K] = denseFactory.from(elems map { _._1 })
+  protected val denseValues: Dense[V] = denseFactory.from(elems map { _._2 })
+  protected val sparseKeysIndices: Sparse[K, Int] = sparseFactory.from(denseKeys.zipWithIndex)
+
+  override def mapFactory: MapFactory[IterableMap] = IterableMap
+
+  override def get(key: K): Option[V] = sparseKeysIndices get key map { denseValues(_) }
+
+  override def iterator: Iterator[(K, V)] = (denseKeys zip denseValues).iterator
+
+  override def keys: scala.Iterable[K] = denseKeys
+
+  override def keySet: Set[K] = Set.from(denseKeys)
+
+  override def keysIterator: Iterator[K] = denseKeys.iterator
+
+  override def values: scala.Iterable[V] = denseValues
+
+  override def valuesIterator: Iterator[V] = denseValues.iterator
+}
+
+object IterableMap extends MapFactory.Delegate[IterableMap](dev.atedeg.ecscala.util.immutable.IterableMap)
 
 private[util] abstract class BaseIterableMapBuilder[K, V, CC[K, V] <: Map[K, V]]
-    extends mutable.ReusableBuilder[(K, V), CC[K, V]] {
+    extends ReusableBuilder[(K, V), CC[K, V]] {
 
   def emptyFactory(): CC[K, V]
   def addElement(map: CC[K, V], elem: (K, V)): CC[K, V]

--- a/src/main/scala/dev/atedeg/ecscala/util/BaseIterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/BaseIterableMap.scala
@@ -1,0 +1,24 @@
+package dev.atedeg.ecscala.util
+
+import scala.collection.Map
+import scala.collection.mutable
+
+private[util] abstract class BaseIterableMapBuilder[K, V, CC[K, V] <: Map[K, V]]
+    extends mutable.ReusableBuilder[(K, V), CC[K, V]] {
+
+  def emptyFactory(): CC[K, V]
+  def addElement(map: CC[K, V], elem: (K, V)): CC[K, V]
+
+  private var elems: CC[K, V] = emptyFactory()
+
+  override def clear(): Unit = {
+    elems = emptyFactory()
+  }
+
+  override def result(): CC[K, V] = elems
+
+  override def addOne(elem: (K, V)): this.type = {
+    elems = addElement(elems, elem)
+    this
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
@@ -1,8 +1,10 @@
 package dev.atedeg.ecscala.util.immutable
 
+import dev.atedeg.ecscala.util.BaseIterableMapBuilder
+
 import scala.collection.generic.DefaultSerializable
 import scala.collection.{MapFactory, MapFactoryDefaults}
-import scala.collection.mutable.{ReusableBuilder, Builder}
+import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.collection.immutable.{AbstractMap, Iterable, MapOps}
 
 trait IterableMap[K, +V]
@@ -50,18 +52,8 @@ object IterableMap extends MapFactory[IterableMap] {
     override def valuesIterator: Iterator[V] = denseValues.iterator
   }
 
-  private class IterableMapBuilderImpl[K, V] extends ReusableBuilder[(K, V), IterableMap[K, V]] {
-    private var elems: IterableMap[K, V] = IterableMap.empty
-
-    override def clear(): Unit = {
-      elems = IterableMap.empty
-    }
-
-    override def result(): IterableMap[K, V] = elems
-
-    override def addOne(elem: (K, V)): this.type = {
-      elems += elem
-      this
-    }
+  private class IterableMapBuilderImpl[K, V] extends BaseIterableMapBuilder[K, V, IterableMap] {
+    override def emptyFactory(): IterableMap[K, V] = IterableMap.empty
+    override def addElement(map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map + elem
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
@@ -7,6 +7,14 @@ import scala.collection.{MapFactory, MapFactoryDefaults}
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import scala.collection.immutable.{AbstractMap, Iterable, MapOps}
 
+/**
+ * This trait represents an immutable [[scala.collection.immutable.Map]] that can be efficiently iterated.
+ *
+ * @tparam K
+ *   the type of the keys contained in this map.
+ * @tparam V
+ *   the type of the values associated with the keys in this map.
+ */
 trait IterableMap[K, +V]
     extends AbstractMap[K, V]
     with MapOps[K, V, IterableMap, IterableMap[K, V]]
@@ -15,6 +23,9 @@ trait IterableMap[K, +V]
   override def mapFactory: MapFactory[IterableMap] = IterableMap
 }
 
+/**
+ * This object provides a set of operations to create [[dev.atedeg.ecscala.util.immutable.IterableMap]] values.
+ */
 object IterableMap extends MapFactory[IterableMap] {
 
   override def empty[K, V]: IterableMap[K, V] = new IterableMapImpl()

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
@@ -25,9 +25,9 @@ object IterableMap extends MapFactory[IterableMap] {
 
   private class IterableMapImpl[K, +V](elems: (K, V)*) extends IterableMap[K, V] {
 
-    private val denseKeys: Vector[K] = Vector(elems map (_._1): _*)
-    private val denseValues: Vector[V] = Vector(elems map (_._2): _*)
-    private val sparseKeysIndices: Map[K, Int] = Map(elems.zipWithIndex.map((elem, index) => (elem._1, index)): _*)
+    private val denseKeys: Vector[K] = Vector.from(elems map (_._1))
+    private val denseValues: Vector[V] = Vector.from(elems map (_._2))
+    private val sparseKeysIndices: Map[K, Int] = Map.from(elems.zipWithIndex.map((elem, index) => (elem._1, index)))
 
     override def removed(key: K): IterableMap[K, V] = IterableMap(denseKeys zip denseValues filter (_._1 != key): _*)
 
@@ -49,10 +49,10 @@ object IterableMap extends MapFactory[IterableMap] {
 
     override def valuesIterator: Iterator[V] = denseValues.iterator
   }
-  
+
   private class IterableMapBuilderImpl[K, V] extends ReusableBuilder[(K, V), IterableMap[K, V]] {
     private var elems: IterableMap[K, V] = IterableMap.empty
-    
+
     override def clear(): Unit = {
       elems = IterableMap.empty
     }

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/IterableMap.scala
@@ -1,0 +1,67 @@
+package dev.atedeg.ecscala.util.immutable
+
+import scala.collection.generic.DefaultSerializable
+import scala.collection.{MapFactory, MapFactoryDefaults}
+import scala.collection.mutable.{ReusableBuilder, Builder}
+import scala.collection.immutable.{AbstractMap, Iterable, MapOps}
+
+trait IterableMap[K, +V]
+    extends AbstractMap[K, V]
+    with MapOps[K, V, IterableMap, IterableMap[K, V]]
+    with MapFactoryDefaults[K, V, IterableMap, Iterable]
+    with DefaultSerializable {
+  override def mapFactory: MapFactory[IterableMap] = IterableMap
+}
+
+object IterableMap extends MapFactory[IterableMap] {
+
+  override def empty[K, V]: IterableMap[K, V] = new IterableMapImpl()
+
+  override def from[K, V](it: IterableOnce[(K, V)]): IterableMap[K, V] = new IterableMapImpl(it.iterator.toSeq: _*)
+
+  override def newBuilder[K, V]: Builder[(K, V), IterableMap[K, V]] = new IterableMapBuilderImpl
+
+  override def apply[K, V](elems: (K, V)*): IterableMap[K, V] = new IterableMapImpl(elems: _*)
+
+  private class IterableMapImpl[K, +V](elems: (K, V)*) extends IterableMap[K, V] {
+
+    private val denseKeys: Vector[K] = Vector(elems map (_._1): _*)
+    private val denseValues: Vector[V] = Vector(elems map (_._2): _*)
+    private val sparseKeysIndices: Map[K, Int] = Map(elems.zipWithIndex.map((elem, index) => (elem._1, index)): _*)
+
+    override def removed(key: K): IterableMap[K, V] = IterableMap(denseKeys zip denseValues filter (_._1 != key): _*)
+
+    override def updated[V1 >: V](key: K, value: V1): IterableMap[K, V1] = IterableMap(
+      (denseKeys zip denseValues filter (_._1 != key)) :+ (key, value): _*
+    )
+
+    override def get(key: K): Option[V] = sparseKeysIndices get key map { denseValues(_) }
+
+    override def iterator: Iterator[(K, V)] = (denseKeys zip denseValues).iterator
+
+    override def keys: scala.Iterable[K] = denseKeys
+
+    override def keySet: Set[K] = Set(denseKeys: _*)
+
+    override def keysIterator: Iterator[K] = denseKeys.iterator
+
+    override def values: scala.Iterable[V] = denseValues
+
+    override def valuesIterator: Iterator[V] = denseValues.iterator
+  }
+  
+  private class IterableMapBuilderImpl[K, V] extends ReusableBuilder[(K, V), IterableMap[K, V]] {
+    private var elems: IterableMap[K, V] = IterableMap.empty
+    
+    override def clear(): Unit = {
+      elems = IterableMap.empty
+    }
+
+    override def result(): IterableMap[K, V] = elems
+
+    override def addOne(elem: (K, V)): this.type = {
+      elems += elem
+      this
+    }
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
@@ -1,0 +1,79 @@
+package dev.atedeg.ecscala.util.mutable
+
+import dev.atedeg.ecscala.util.BaseIterableMapBuilder
+
+import scala.collection.generic.DefaultSerializable
+import scala.collection.{MapFactory, MapFactoryDefaults, mutable}
+import scala.collection.mutable.{AbstractMap, ArrayBuffer, Builder, Iterable, Map, MapOps, ReusableBuilder}
+
+trait IterableMap[K, V]
+    extends AbstractMap[K, V]
+    with MapOps[K, V, IterableMap, IterableMap[K, V]]
+    with MapFactoryDefaults[K, V, IterableMap, Iterable]
+    with DefaultSerializable {
+  override def mapFactory: MapFactory[IterableMap] = IterableMap
+}
+
+object IterableMap extends MapFactory[IterableMap] {
+
+  override def empty[K, V]: IterableMap[K, V] = new IterableMapImpl()
+
+  override def from[K, V](it: IterableOnce[(K, V)]): IterableMap[K, V] = new IterableMapImpl(it.iterator.toSeq: _*)
+
+  override def newBuilder[K, V]: mutable.Builder[(K, V), IterableMap[K, V]] = new IterableMapBuilderImpl
+
+  override def apply[K, V](elems: (K, V)*): IterableMap[K, V] = new IterableMapImpl(elems: _*)
+
+  private class IterableMapImpl[K, V](elems: (K, V)*) extends IterableMap[K, V] {
+
+    private val denseKeys: ArrayBuffer[K] = ArrayBuffer.from(elems map (_._1))
+    private val denseValues: ArrayBuffer[V] = ArrayBuffer.from(elems map (_._2))
+    private val sparseKeysIndices: Map[K, Int] = Map.from(elems.zipWithIndex.map((elem, index) => (elem._1, index)))
+
+    override def addOne(elem: (K, V)): this.type = {
+      val denseIndex = denseKeys.size + 1
+      denseKeys += elem._1
+      denseValues += elem._2
+      sparseKeysIndices += (elem._1 -> denseIndex)
+      this
+    }
+
+    override def subtractOne(elem: K): this.type = {
+      // We switch the last item in place of the one we deleted
+      val elemIndex = sparseKeysIndices get elem
+      elemIndex match {
+        case Some(index) => {
+          sparseKeysIndices -= elem
+          if (index != denseKeys.size - 1) {
+            denseKeys(index) = denseKeys.last
+            denseValues(index) = denseValues.last
+            sparseKeysIndices += (denseKeys.last -> index)
+          }
+          denseKeys.dropRightInPlace(1)
+          denseValues.dropRightInPlace(1)
+          this
+        }
+        case None => this
+      }
+    }
+
+    override def get(key: K): Option[V] = sparseKeysIndices get key map { denseValues(_) }
+
+    override def iterator: Iterator[(K, V)] = (denseKeys zip denseValues).iterator
+
+    override def keys: scala.Iterable[K] = denseKeys
+
+    override def keySet: Set[K] = Set.from(denseKeys)
+
+    override def keysIterator: Iterator[K] = denseKeys.iterator
+
+    override def values: scala.Iterable[V] = denseValues
+
+    override def valuesIterator: Iterator[V] = denseValues.iterator
+  }
+
+  private class IterableMapBuilderImpl[K, V] extends BaseIterableMapBuilder[K, V, IterableMap] {
+    override def emptyFactory(): IterableMap[K, V] = IterableMap.empty
+    override def addElement(map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map.addOne(elem)
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
@@ -73,6 +73,7 @@ object IterableMap extends MapFactory[IterableMap] {
   }
 
   private class IterableMapBuilderImpl[K, V] extends BaseIterableMapBuilder[K, V, IterableMap] {
+
     override def emptyFactory(): IterableMap[K, V] = IterableMap.empty
     override def addElement(map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map.addOne(elem)
   }

--- a/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
@@ -6,6 +6,14 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.{MapFactory, MapFactoryDefaults, mutable}
 import scala.collection.mutable.{AbstractMap, ArrayBuffer, Builder, Iterable, Map, MapOps, ReusableBuilder}
 
+/**
+ * This trait represents a mutable [[scala.collection.mutable.Map]] that can be efficiently iterated.
+ *
+ * @tparam K
+ *   the type of the keys contained in this map.
+ * @tparam V
+ *   the type of the values associated with the keys in this map.
+ */
 trait IterableMap[K, V]
     extends AbstractMap[K, V]
     with MapOps[K, V, IterableMap, IterableMap[K, V]]
@@ -14,6 +22,9 @@ trait IterableMap[K, V]
   override def mapFactory: MapFactory[IterableMap] = IterableMap
 }
 
+/**
+ * This object provides a set of operations to create [[dev.atedeg.ecscala.util.mutable.IterableMap]] values.
+ */
 object IterableMap extends MapFactory[IterableMap] {
 
   override def empty[K, V]: IterableMap[K, V] = new IterableMapImpl()

--- a/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/mutable/IterableMap.scala
@@ -31,21 +31,22 @@ object IterableMap extends MapFactory[IterableMap] {
 
   override def from[K, V](it: IterableOnce[(K, V)]): IterableMap[K, V] = new IterableMapImpl(it.iterator.toSeq: _*)
 
-  override def newBuilder[K, V]: mutable.Builder[(K, V), IterableMap[K, V]] = new IterableMapBuilderImpl
+  override def newBuilder[K, V]: mutable.Builder[(K, V), IterableMap[K, V]] = new IterableMapBuilderImpl()
 
   override def apply[K, V](elems: (K, V)*): IterableMap[K, V] = new IterableMapImpl(elems: _*)
 
   private class IterableMapImpl[K, V](elems: (K, V)*) extends IterableMap[K, V] {
 
-    private val denseKeys: ArrayBuffer[K] = ArrayBuffer.from(elems map (_._1))
-    private val denseValues: ArrayBuffer[V] = ArrayBuffer.from(elems map (_._2))
-    private val sparseKeysIndices: Map[K, Int] = Map.from(elems.zipWithIndex.map((elem, index) => (elem._1, index)))
+    private val denseKeys: ArrayBuffer[K] = ArrayBuffer.from(elems map { _._1 })
+    private val denseValues: ArrayBuffer[V] = ArrayBuffer.from(elems map { _._2 })
+    private val sparseKeysIndices: Map[K, Int] = Map.from(denseKeys.zipWithIndex)
 
     override def addOne(elem: (K, V)): this.type = {
+      val (key, value) = elem
       val denseIndex = denseKeys.size + 1
-      denseKeys += elem._1
-      denseValues += elem._2
-      sparseKeysIndices += (elem._1 -> denseIndex)
+      denseKeys += key
+      denseValues += value
+      sparseKeysIndices += (key -> denseIndex)
       this
     }
 

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
@@ -10,7 +10,7 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
   def add[K, V](map: CC[K, V], elem: (K, V)): CC[K, V]
   def remove[K, V](map: CC[K, V], key: K): CC[K, V]
 
-  "An immutable iterable map" when {
+  "An iterable map" when {
     "empty" should {
       "have size 0" in {
         iterableMapFactory().empty.size shouldBe 0

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
@@ -30,6 +30,11 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
           map = remove(map, "test")
           map.size shouldBe 0
         }
+        "removing a non-existing element" in {
+          var map: CC[String, Int] = iterableMapFactory().empty
+          map = remove(map, "test")
+          map.size shouldBe 0
+        }
       }
     }
     "has 100 elements" should {
@@ -41,6 +46,17 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
       }
       "return None for a non-existing element" in new Fixture {
         map get 1000 shouldBe None
+      }
+      "return the correct element" when {
+        "deleting the last one" in new Fixture {
+          val removed = remove(map, 99)
+          removed get 99 shouldBe None
+        }
+        "deleting the middle one" in new Fixture {
+          val removed = remove(map, 50)
+          removed get 50 shouldBe None
+          removed get 99 shouldBe Some(198)
+        }
       }
       "return all the keys" in new Fixture {
         map.keys shouldBe (0 until 100)

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
@@ -6,11 +6,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.{Map, MapFactory}
 
 abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec with Matchers {
+  def name: String
   def iterableMapFactory(): MapFactory[CC]
   def add[K, V](map: CC[K, V], elem: (K, V)): CC[K, V]
   def remove[K, V](map: CC[K, V], key: K): CC[K, V]
 
-  "An iterable map" when {
+  s"$name" when {
     "empty" should {
       "have size 0" in {
         iterableMapFactory().empty.size shouldBe 0
@@ -71,7 +72,7 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
       }
     }
   }
-  "An immutable iterable map builder" should {
+  s"$name builder" should {
     "create an iterable map" in {
       val builder = iterableMapFactory().newBuilder[String, Int]
       builder += ("test1" -> 1)

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseIterableMapTests.scala
@@ -1,0 +1,69 @@
+package dev.atedeg.ecscala.util
+
+import org.scalatest.matchers.should.*
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.{Map, MapFactory}
+
+abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec with Matchers {
+  def iterableMapFactory(): MapFactory[CC]
+  def add[K, V](map: CC[K, V], elem: (K, V)): CC[K, V]
+  def remove[K, V](map: CC[K, V], key: K): CC[K, V]
+
+  "An immutable iterable map" when {
+    "empty" should {
+      "have size 0" in {
+        iterableMapFactory().empty.size shouldBe 0
+      }
+      "have size 1" when {
+        "adding an element" in {
+          var map: CC[String, Int] = iterableMapFactory().empty
+          map = add(map, "test" -> 1)
+          map.size shouldBe 1
+        }
+      }
+    }
+    "has 1 element" should {
+      "have size 0" when {
+        "removing an element" in {
+          var map: CC[String, Int] = iterableMapFactory()("test" -> 1)
+          map = remove(map, "test")
+          map.size shouldBe 0
+        }
+      }
+    }
+    "has 100 elements" should {
+      trait Fixture {
+        val map: CC[Int, Int] = iterableMapFactory().from((0 until 100) map { i => (i, 2 * i) })
+      }
+      "find an existing element" in new Fixture {
+        map get 50 shouldBe Some(100)
+      }
+      "return None for a non-existing element" in new Fixture {
+        map get 1000 shouldBe None
+      }
+      "return all the keys" in new Fixture {
+        map.keys shouldBe (0 until 100)
+        map.keysIterator.to(LazyList) shouldBe (0 until 100).iterator.to(LazyList)
+      }
+      "return a set with all the keys" in new Fixture {
+        map.keySet should contain theSameElementsAs (0 until 100)
+      }
+      "return all the values" in new Fixture {
+        map.values shouldBe (0 until 200 by 2)
+        map.valuesIterator.to(LazyList) shouldBe (0 until 200 by 2).iterator.to(LazyList)
+      }
+    }
+  }
+  "An immutable iterable map builder" should {
+    "create an iterable map" in {
+      val builder = iterableMapFactory().newBuilder[String, Int]
+      builder += ("test1" -> 1)
+      builder += ("test2" -> 2)
+      builder += ("test3" -> 3)
+      builder.result shouldBe iterableMapFactory()("test1" -> 1, "test2" -> 2, "test3" -> 3)
+      builder.clear()
+      builder.result shouldBe iterableMapFactory().empty
+    }
+  }
+}

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseMapTests.scala
@@ -5,20 +5,20 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.{Map, MapFactory}
 
-abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec with Matchers {
+abstract class BaseMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec with Matchers {
   def name: String
-  def iterableMapFactory(): MapFactory[CC]
+  def mapFactory(): MapFactory[CC]
   def add[K, V](map: CC[K, V], elem: (K, V)): CC[K, V]
   def remove[K, V](map: CC[K, V], key: K): CC[K, V]
 
   s"$name" when {
     "empty" should {
       "have size 0" in {
-        iterableMapFactory().empty.size shouldBe 0
+        mapFactory().empty.size shouldBe 0
       }
       "have size 1" when {
         "adding an element" in {
-          var map: CC[String, Int] = iterableMapFactory().empty
+          var map: CC[String, Int] = mapFactory().empty
           map = add(map, "test" -> 1)
           map.size shouldBe 1
         }
@@ -27,20 +27,22 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
     "has 1 element" should {
       "have size 0" when {
         "removing an element" in {
-          var map: CC[String, Int] = iterableMapFactory()("test" -> 1)
+          var map: CC[String, Int] = mapFactory()("test" -> 1)
           map = remove(map, "test")
           map.size shouldBe 0
         }
+      }
+      "have size 1" when {
         "removing a non-existing element" in {
-          var map: CC[String, Int] = iterableMapFactory().empty
+          var map: CC[String, Int] = mapFactory()("key" -> 1)
           map = remove(map, "test")
-          map.size shouldBe 0
+          map.size shouldBe 1
         }
       }
     }
     "has 100 elements" should {
       trait Fixture {
-        val map: CC[Int, Int] = iterableMapFactory().from((0 until 100) map { i => (i, 2 * i) })
+        val map: CC[Int, Int] = mapFactory().from((0 until 100) map { i => (i, 2 * i) })
       }
       "find an existing element" in new Fixture {
         map get 50 shouldBe Some(100)
@@ -60,27 +62,27 @@ abstract class BaseIterableMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec w
         }
       }
       "return all the keys" in new Fixture {
-        map.keys shouldBe (0 until 100)
-        map.keysIterator.to(LazyList) shouldBe (0 until 100).iterator.to(LazyList)
+        map.keys should contain theSameElementsAs (0 until 100)
+        map.keysIterator.to(LazyList) should contain theSameElementsAs (0 until 100).iterator.to(LazyList)
       }
       "return a set with all the keys" in new Fixture {
         map.keySet should contain theSameElementsAs (0 until 100)
       }
       "return all the values" in new Fixture {
-        map.values shouldBe (0 until 200 by 2)
-        map.valuesIterator.to(LazyList) shouldBe (0 until 200 by 2).iterator.to(LazyList)
+        map.values should contain theSameElementsAs (0 until 200 by 2)
+        map.valuesIterator.to(LazyList) should contain theSameElementsAs (0 until 200 by 2).iterator.to(LazyList)
       }
     }
   }
   s"$name builder" should {
     "create an iterable map" in {
-      val builder = iterableMapFactory().newBuilder[String, Int]
+      val builder = mapFactory().newBuilder[String, Int]
       builder += ("test1" -> 1)
       builder += ("test2" -> 2)
       builder += ("test3" -> 3)
-      builder.result shouldBe iterableMapFactory()("test1" -> 1, "test2" -> 2, "test3" -> 3)
+      builder.result shouldBe mapFactory()("test1" -> 1, "test2" -> 2, "test3" -> 3)
       builder.clear()
-      builder.result shouldBe iterableMapFactory().empty
+      builder.result shouldBe mapFactory().empty
     }
   }
 }

--- a/src/test/scala/dev/atedeg/ecscala/util/BaseMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/BaseMapTests.scala
@@ -6,6 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.collection.{Map, MapFactory}
 
 abstract class BaseMapTests[CC[K, V] <: Map[K, V]] extends AnyWordSpec with Matchers {
+
   def name: String
   def mapFactory(): MapFactory[CC]
   def add[K, V](map: CC[K, V], elem: (K, V)): CC[K, V]

--- a/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
@@ -1,63 +1,14 @@
 package dev.atedeg.ecscala.util.immutable
 
-import org.scalatest.matchers.should.*
-import org.scalatest.wordspec.AnyWordSpec
+import dev.atedeg.ecscala.util.BaseIterableMapTests
 
-class IterableMapTests extends AnyWordSpec with Matchers {
-  "An immutable iterable map" when {
-    "empty" should {
-      "have size 0" in {
-        IterableMap[String, Int]().size shouldBe 0
-      }
-      "have size 1" when {
-        "adding an element" in {
-          var map: Map[String, Int] = IterableMap.empty
-          map = map + ("test" -> 1)
-          map.size shouldBe 1
-        }
-      }
-    }
-    "has 1 element" should {
-      "have size 0" when {
-        "removing an element" in {
-          var map: Map[String, Int] = IterableMap("test" -> 1)
-          map = map - "test"
-          map.size shouldBe 0
-        }
-      }
-    }
-    "has 100 elements" should {
-      trait Fixture {
-        val map: Map[Int, Int] = IterableMap.from((0 until 100) map { i => (i, 2 * i) })
-      }
-      "find an existing element" in new Fixture {
-        map get 50 shouldBe Some(100)
-      }
-      "return None for a non-existing element" in new Fixture {
-        map get 1000 shouldBe None
-      }
-      "return all the keys" in new Fixture {
-        map.keys shouldBe (0 until 100)
-        map.keysIterator.to(LazyList) shouldBe (0 until 100).iterator.to(LazyList)
-      }
-      "return a set with all the keys" in new Fixture {
-        map.keySet should contain theSameElementsAs (0 until 100)
-      }
-      "return all the values" in new Fixture {
-        map.values shouldBe (0 until 200 by 2)
-        map.valuesIterator.to(LazyList) shouldBe (0 until 200 by 2).iterator.to(LazyList)
-      }
-    }
-  }
-  "An immutable iterable map builder" should {
-    "create an iterable map" in {
-      val builder = IterableMap.newBuilder[String, Int]
-      builder += ("test1" -> 1)
-      builder += ("test2" -> 2)
-      builder += ("test3" -> 3)
-      builder.result shouldBe IterableMap("test1" -> 1, "test2" -> 2, "test3" -> 3)
-      builder.clear()
-      builder.result shouldBe IterableMap.empty
-    }
-  }
+import scala.collection.{Map, MapFactory}
+
+class IterableMapTests extends BaseIterableMapTests[IterableMap] {
+
+  override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
+
+  override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map + elem
+
+  override def remove[K, V](map: IterableMap[K, V], key: K): IterableMap[K, V] = map - key
 }

--- a/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
@@ -1,0 +1,63 @@
+package dev.atedeg.ecscala.util.immutable
+
+import org.scalatest.matchers.should.*
+import org.scalatest.wordspec.AnyWordSpec
+
+class IterableMapTests extends AnyWordSpec with Matchers {
+  "An immutable iterable map" when {
+    "empty" should {
+      "have size 0" in {
+        IterableMap[String, Int]().size shouldBe 0
+      }
+      "have size 1" when {
+        "adding an element" in {
+          var map: Map[String, Int] = IterableMap.empty
+          map = map + ("test" -> 1)
+          map.size shouldBe 1
+        }
+      }
+    }
+    "has 1 element" should {
+      "have size 0" when {
+        "removing an element" in {
+          var map: Map[String, Int] = IterableMap("test" -> 1)
+          map = map - "test"
+          map.size shouldBe 0
+        }
+      }
+    }
+    "has 100 elements" should {
+      trait Fixture {
+        val map: Map[Int, Int] = IterableMap.from((0 until 100) map { i => (i, 2 * i) })
+      }
+      "find an existing element" in new Fixture {
+        map get 50 shouldBe Some(100)
+      }
+      "return None for a non-existing element" in new Fixture {
+        map get 1000 shouldBe None
+      }
+      "return all the keys" in new Fixture {
+        map.keys shouldBe (0 until 100)
+        map.keysIterator.to(LazyList) shouldBe (0 until 100).iterator.to(LazyList)
+      }
+      "return a set with all the keys" in new Fixture {
+        map.keySet should contain theSameElementsAs (0 until 100)
+      }
+      "return all the values" in new Fixture {
+        map.values shouldBe (0 until 200 by 2)
+        map.valuesIterator.to(LazyList) shouldBe (0 until 200 by 2).iterator.to(LazyList)
+      }
+    }
+  }
+  "An immutable iterable map builder" should {
+    "create an iterable map" in {
+      val builder = IterableMap.newBuilder[String, Int]
+      builder += ("test1" -> 1)
+      builder += ("test2" -> 2)
+      builder += ("test3" -> 3)
+      builder.result shouldBe IterableMap("test1" -> 1, "test2" -> 2, "test3" -> 3)
+      builder.clear()
+      builder.result shouldBe IterableMap.empty
+    }
+  }
+}

--- a/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
@@ -6,6 +6,8 @@ import scala.collection.{Map, MapFactory}
 
 class IterableMapTests extends BaseIterableMapTests[IterableMap] {
 
+  override def name: String = "An immutable iterable map"
+
   override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
 
   override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map + elem

--- a/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/immutable/IterableMapTests.scala
@@ -1,14 +1,14 @@
 package dev.atedeg.ecscala.util.immutable
 
-import dev.atedeg.ecscala.util.BaseIterableMapTests
+import dev.atedeg.ecscala.util.BaseMapTests
 
 import scala.collection.{Map, MapFactory}
 
-class IterableMapTests extends BaseIterableMapTests[IterableMap] {
+class IterableMapTests extends BaseMapTests[IterableMap] {
 
   override def name: String = "An immutable iterable map"
 
-  override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
+  override def mapFactory(): MapFactory[IterableMap] = IterableMap
 
   override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = map + elem
 

--- a/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
@@ -1,15 +1,15 @@
 package dev.atedeg.ecscala.util.mutable
 
-import dev.atedeg.ecscala.util.BaseIterableMapTests
+import dev.atedeg.ecscala.util.BaseMapTests
 
 import scala.collection.MapFactory
 import scala.collection.{Map, MapFactory}
 
-class IterableMapTests extends BaseIterableMapTests[IterableMap] {
+class IterableMapTests extends BaseMapTests[IterableMap] {
 
   override def name: String = "A mutable iterable map"
 
-  override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
+  override def mapFactory(): MapFactory[IterableMap] = IterableMap
 
   override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = {
     map += elem

--- a/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
@@ -1,0 +1,21 @@
+package dev.atedeg.ecscala.util.mutable
+
+import dev.atedeg.ecscala.util.BaseIterableMapTests
+
+import scala.collection.MapFactory
+import scala.collection.{Map, MapFactory}
+
+class IterableMapTests extends BaseIterableMapTests[IterableMap] {
+
+  override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
+
+  override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = {
+    map += elem
+    map
+  }
+
+  override def remove[K, V](map: IterableMap[K, V], key: K): IterableMap[K, V] = {
+    map -= key
+    map
+  }
+}

--- a/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/mutable/IterableMapTests.scala
@@ -7,6 +7,8 @@ import scala.collection.{Map, MapFactory}
 
 class IterableMapTests extends BaseIterableMapTests[IterableMap] {
 
+  override def name: String = "A mutable iterable map"
+
   override def iterableMapFactory(): MapFactory[IterableMap] = IterableMap
 
   override def add[K, V](map: IterableMap[K, V], elem: (K, V)): IterableMap[K, V] = {


### PR DESCRIPTION
This PR introduces the Iterable Map in its immutable and mutable variants, for a more efficient iteration than the default Map implementations.
To achieve this, it uses two dense vectors that store the keys and values, plus a regular Map that associates keys with their indices in the dense vector for fast lookup.
This data structure can be seen as a generalization of a sparse set.

Closes #25 