### PR TITLE
TypeTag

### DIFF
--- a/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -3,11 +3,11 @@ package dev.atedeg.ecscala.util.types
 import scala.quoted.*
 
 /**
- * A TypeTag is a trait used to describe types keeping informations about the type that would otherwise be erased at
+ * A TypeTag is a trait used to describe types keeping information about the type that would otherwise be erased at
  * runtime.
  *
  * @tparam T
- *   the type whose compiletime informations are stored in the TypeTag.
+ *   the type whose compiletime information are stored in the TypeTag.
  */
 private[ecscala] sealed trait TypeTag[T] {
   override def equals(obj: Any): Boolean

--- a/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -1,0 +1,31 @@
+package dev.atedeg.ecscala.util.types
+
+import scala.quoted.*
+
+/**
+ * A TypeTag is a trait used to describe types keeping informations about the type that would otherwise be erased at
+ * runtime.
+ *
+ * @tparam T
+ *   the type whose compiletime informations are stored in the TypeTag.
+ */
+sealed trait TypeTag[T] {
+  override def equals(obj: Any): Boolean
+  override def hashCode(): Int
+  override def toString: String
+}
+
+inline given [T]: TypeTag[T] = ${ deriveTypeTagImpl[T] }
+private def deriveTypeTagImpl[T: Type](using quotes: Quotes): Expr[TypeTag[T]] = {
+  import quotes.reflect.*
+  '{
+    new TypeTag[T] {
+      override def toString: String = ${ Expr(TypeRepr.of[T].show) }
+      override def hashCode: Int = this.toString.hashCode
+      override def equals(obj: Any) = obj match {
+        case that: TypeTag[_] => that.toString == this.toString
+        case _                => false
+      }
+    }
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -9,11 +9,7 @@ import scala.quoted.*
  * @tparam T
  *   the type whose compiletime information are stored in the TypeTag.
  */
-private[ecscala] sealed trait TypeTag[T] {
-  override def equals(obj: Any): Boolean
-  override def hashCode(): Int
-  override def toString: String
-}
+private[ecscala] sealed trait TypeTag[T]
 
 inline given [T]: TypeTag[T] = ${ deriveTypeTagImpl[T] }
 private def deriveTypeTagImpl[T: Type](using quotes: Quotes): Expr[TypeTag[T]] = {

--- a/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -9,7 +9,7 @@ import scala.quoted.*
  * @tparam T
  *   the type whose compiletime informations are stored in the TypeTag.
  */
-sealed trait TypeTag[T] {
+private[ecscala] sealed trait TypeTag[T] {
   override def equals(obj: Any): Boolean
   override def hashCode(): Int
   override def toString: String

--- a/src/test/scala/dev/atedeg/ecscala/util/types/TypeTagTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/types/TypeTagTest.scala
@@ -1,0 +1,27 @@
+package dev.atedeg.ecscala.util.types
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TypeTagTest extends AnyWordSpec with Matchers {
+  def assertTagsEqual[A, B](using ttA: TypeTag[A], ttB: TypeTag[B]): Unit = {
+    ttA shouldEqual ttB
+    ttB shouldEqual ttA
+  }
+  def assertTagsNotEqual[A, B](using ttA: TypeTag[A], ttB: TypeTag[B]): Unit = {
+    ttA should not equal ttB
+    ttB should not equal ttA
+  }
+
+  "A TypeTag[Int]" should {
+    "be equal to TypeTag[Int]" in assertTagsEqual[Int, Int]
+    "not be equal to TypeTag[String]" in assertTagsNotEqual[Int, String]
+    "not be equal to TypeTag[Any]" in assertTagsNotEqual[Int, Any]
+  }
+
+  "A TypeTag[List[Int]]" should {
+    "be equal to TypeTag[List[Int]]" in assertTagsEqual[List[Int], List[Int]]
+    "not be equal to TypeTag[List[String]]" in assertTagsNotEqual[List[Int], List[String]]
+    "not be equal to TypeTag[List[Any]]" in assertTagsNotEqual[List[Int], List[Any]]
+  }
+}


### PR DESCRIPTION
This PR introduces the `trait TypeTag[T]` which can be used to perform equality checks on types that would otherwise be erased at runtime.