### PR TITLE
World implementation

### DIFF
--- a/process/sprint2.csv
+++ b/process/sprint2.csv
@@ -9,5 +9,5 @@ As a framework user I want to manipulate the  World's Entities,Define Entities t
 As a framework user I want to manipulate the Entities' Components,Implement methods to add and remove components to an entity,,Linda Vitali,10,8,7,,,,,
 ,Implement component type,,Linda Vitali,2,2,1,,,,,
 ,Design detailed Component's architecture,,Linda Vitali,8,10,2,,,,,
-As a framework user I want to define World's Views,Define a type-safe way to create Views,,Giacomo Cavalieri,28,28,,,,,,
-,Implement World's getView method,,Giacomo Cavalieri,2,2,,,,,,
+As a framework user I want to define World's Views,Define a type-safe way to create Views,,Giacomo Cavalieri,28,28,25,25,25,25,20,20
+,Implement World's getView method,,Giacomo Cavalieri,2,2,2,2,2,2,2,2

--- a/src/main/scala/dev/atedeg/ecscala/Component.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Component.scala
@@ -4,6 +4,6 @@ trait Component {
   private var _entity: Option[Entity] = Option.empty
   def entity: Option[Entity] = _entity
   private[ecscala] def setEntity(entity: Option[Entity]): Unit = {
-    myEntity = entity
+    _entity = entity
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/Component.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Component.scala
@@ -1,0 +1,3 @@
+package dev.atedeg.ecscala
+
+trait Component

--- a/src/main/scala/dev/atedeg/ecscala/Component.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Component.scala
@@ -1,3 +1,9 @@
 package dev.atedeg.ecscala
 
-trait Component
+trait Component {
+  private var _entity: Option[Entity] = Option.empty
+  def entity: Option[Entity] = _entity
+  private[ecscala] def setEntity(entity: Option[Entity]): Unit = {
+    myEntity = entity
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/Component.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Component.scala
@@ -1,5 +1,8 @@
 package dev.atedeg.ecscala
 
+/**
+ * This trait represents an [[Entity]] 's feature.
+ */
 trait Component {
   private var _entity: Option[Entity] = Option.empty
   def entity: Option[Entity] = _entity

--- a/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -8,19 +8,25 @@ import dev.atedeg.ecscala.util.types.TypeTag
  * This trait represents an entity of ECS whose state is defined by its components.
  */
 sealed trait Entity {
-  
-  /**
-   * @param component the [[Component]] to add to the [[Entity]].
-   * @tparam T the type of the [[Component]].
-   * @return itself.
-   */
-  def addComponent[T <: Component](component: T): Entity
 
   /**
-   * @param handler the handler to execute when a [[Component]] is added to this entity.
-   * @return itself.
+   * @param component
+   *   the [[Component]] to add to the [[Entity]].
+   * @tparam T
+   *   the type of the [[Component]].
+   * @return
+   *   itself.
    */
-  def onAddedComponent(handler: ((Entity, Component)) => Unit): Entity
+  def addComponent[T <: Component: TypeTag](component: T): Entity
+
+  /**
+   * @param handler
+   *   the handler to execute when a [[Component]] is added to this entity.
+   * @return
+   *   itself.
+   */
+  // TODO: try to understand if this could be made public to the library user without having to expose the TypeTag[T] trait
+  private[ecscala] def onAddedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit): Entity
 }
 
 /**
@@ -32,14 +38,14 @@ object Entity {
   protected[ecscala] def apply(): Entity = EntityImpl(IdGenerator.nextId())
 
   private case class EntityImpl(private val id: Id) extends Entity {
-    private var onAddedComponentEvent: Event[(Entity, Component)] = Event()
-
-    override def addComponent[T <: Component](component: T): Entity = {
-      onAddedComponentEvent(this, component)
+    private var onAddedComponentEvent: Event[(Entity, TypeTag[Component], Component)] = Event()
+    
+    override def addComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
+      onAddedComponentEvent(this, tt, component)
       this
     }
 
-    override def onAddedComponent(handler: ((Entity, Component)) => Unit): Entity = {
+    override def onAddedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit): Entity = {
       onAddedComponentEvent += handler
       this
     }

--- a/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -59,6 +59,7 @@ object Entity {
     private var onRemovedComponentEvent: Event[(Entity, TypeTag[Component], Component)] = Event()
 
     override def addComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
+      component.setEntity(Some(this))
       onAddedComponentEvent(this, tt, component)
       this
     }
@@ -69,6 +70,7 @@ object Entity {
     }
 
     override def removeComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
+      component.setEntity(None)
       onRemovedComponentEvent(this, tt, component)
       this
     }

--- a/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -1,9 +1,27 @@
 package dev.atedeg.ecscala
 
+import dev.atedeg.ecscala.util.Event
+import dev.atedeg.ecscala.util.immutable.ComponentsContainer
+import dev.atedeg.ecscala.util.types.TypeTag
+
 /**
  * This trait represents an entity of ECS whose state is defined by its components.
  */
-sealed trait Entity
+sealed trait Entity {
+  
+  /**
+   * @param component the [[Component]] to add to the [[Entity]].
+   * @tparam T the type of the [[Component]].
+   * @return itself.
+   */
+  def addComponent[T <: Component](component: T): Entity
+
+  /**
+   * @param handler the handler to execute when a [[Component]] is added to this entity.
+   * @return itself.
+   */
+  def onAddedComponent(handler: ((Entity, Component)) => Unit): Entity
+}
 
 /**
  * Factory for [[dev.atedeg.ecscala.Entity]] instances.
@@ -13,7 +31,19 @@ object Entity {
 
   protected[ecscala] def apply(): Entity = EntityImpl(IdGenerator.nextId())
 
-  private case class EntityImpl(private val id: Id) extends Entity
+  private case class EntityImpl(private val id: Id) extends Entity {
+    private var onAddedComponentEvent: Event[(Entity, Component)] = Event()
+
+    override def addComponent[T <: Component](component: T): Entity = {
+      onAddedComponentEvent(this, component)
+      this
+    }
+
+    override def onAddedComponent(handler: ((Entity, Component)) => Unit): Entity = {
+      onAddedComponentEvent += handler
+      this
+    }
+  }
 
   private object IdGenerator {
     private var currentId: Id = 0

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -53,7 +53,9 @@ object World {
     override def createEntity(): Entity = {
       val entity = Entity()
       entity.onAddedComponent((e, tt, c) => (componentsContainer = componentsContainer.addComponent(e, c)(using tt)))
-      entity.onRemovedComponent((e, tt, c) => (componentsContainer = componentsContainer.removeComponent(e, c)(using tt)))
+      entity.onRemovedComponent((e, tt, c) =>
+        (componentsContainer = componentsContainer.removeComponent(e, c)(using tt))
+      )
       entities += entity
       entity
     }

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -1,6 +1,7 @@
 package dev.atedeg.ecscala
 
 import dev.atedeg.ecscala.util.immutable.ComponentsContainer
+import dev.atedeg.ecscala.util.types.TypeTag
 
 /**
  * This trait represents a container for [[Entity]], Components and System.
@@ -27,6 +28,8 @@ trait World {
    *   to remove.
    */
   def removeEntity(entity: Entity): Unit
+
+  private[ecscala] def getComponents[T <: Component: TypeTag]: Option[Map[Entity, T]]
 }
 
 /**
@@ -48,7 +51,9 @@ object World {
     override def entitiesCount: Int = entities.size
 
     override def createEntity(): Entity = {
+      import dev.atedeg.ecscala.util.types.{given TypeTag[_]}
       val entity = Entity()
+      entity.onAddedComponent(componentsContainer += _)
       entities += entity
       entity
     }
@@ -57,5 +62,7 @@ object World {
       entities -= entity
       componentsContainer -= entity
     }
+
+    override private[ecscala] def getComponents[T <: Component: TypeTag] = componentsContainer[T]
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -53,6 +53,7 @@ object World {
     override def createEntity(): Entity = {
       val entity = Entity()
       entity.onAddedComponent((e, tt, c) => (componentsContainer = componentsContainer.addComponent(e, c)(using tt)))
+      entity.onRemovedComponent((e, tt, c) => (componentsContainer = componentsContainer.removeComponent(e, c)(using tt)))
       entities += entity
       entity
     }

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -40,16 +40,16 @@ object World {
   def apply(): World = new WorldImpl()
 
   private class WorldImpl() extends World {
-    private var entities: Set[Entity] = Set()
-
-    override def entitiesCount: Int = entities.size
+    private var _entitiesCount: Int = 0
+    
+    override def entitiesCount: Int = _entitiesCount
 
     override def createEntity(): Entity = {
       val entity = Entity()
-      entities += entity
+      _entitiesCount += 1
       entity
     }
 
-    override def removeEntity(entity: Entity): Unit = entities -= entity
+    override def removeEntity(entity: Entity): Unit = _entitiesCount -= 1
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -1,5 +1,7 @@
 package dev.atedeg.ecscala
 
+import dev.atedeg.ecscala.util.immutable.ComponentsContainer
+
 /**
  * This trait represents a container for [[Entity]], Components and System.
  */
@@ -40,16 +42,20 @@ object World {
   def apply(): World = new WorldImpl()
 
   private class WorldImpl() extends World {
-    private var _entitiesCount: Int = 0
-    
-    override def entitiesCount: Int = _entitiesCount
+    private var entities: Set[Entity] = Set()
+    private var componentsContainer = ComponentsContainer()
+
+    override def entitiesCount: Int = entities.size
 
     override def createEntity(): Entity = {
       val entity = Entity()
-      _entitiesCount += 1
+      entities += entity
       entity
     }
 
-    override def removeEntity(entity: Entity): Unit = _entitiesCount -= 1
+    override def removeEntity(entity: Entity): Unit = {
+      entities -= entity
+      componentsContainer -= entity
+    }
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -51,9 +51,8 @@ object World {
     override def entitiesCount: Int = entities.size
 
     override def createEntity(): Entity = {
-      import dev.atedeg.ecscala.util.types.{given TypeTag[_]}
       val entity = Entity()
-      entity.onAddedComponent(componentsContainer += _)
+      entity.onAddedComponent((e, tt, c) => (componentsContainer = componentsContainer.addComponent(e, c)(using tt)))
       entities += entity
       entity
     }

--- a/src/main/scala/dev/atedeg/ecscala/util/Event.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/Event.scala
@@ -27,6 +27,19 @@ trait Event[T] {
    * An alias for [[registerHandler]].
    */
   def +(handler: T => Unit) = registerHandler(handler)
+
+  /**
+   * @param handler
+   *   the handler that will be removed.
+   * @return
+   *   a new [[Event]] with the removed handler.
+   */
+  def removeHandler(handler: T => Unit): Event[T]
+
+  /**
+   * An alias for [[removeHandler()]].
+   */
+  def -(handler: T => Unit) = removeHandler(handler)
 }
 
 object Event {
@@ -36,5 +49,6 @@ object Event {
   private class EventImpl[T](private val handlers: Seq[T => Unit]) extends Event[T] {
     override def apply(eventParam: T): Unit = handlers map (_(eventParam))
     override def registerHandler(handler: T => Unit): Event[T] = Event(handlers :+ handler)
+    override def removeHandler(handler: T => Unit): Event[T] = Event(handlers filterNot (_ == handler))
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/util/Event.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/Event.scala
@@ -43,7 +43,7 @@ trait Event[T] {
 }
 
 object Event {
-  def apply[T](): Event[T] = new EventImpl[T](Seq())
+  def apply[T](): Event[T] = new EventImpl(Seq())
   private def apply[T](handlers: Seq[T => Unit]): Event[T] = new EventImpl(handlers)
 
   private class EventImpl[T](private val handlers: Seq[T => Unit]) extends Event[T] {

--- a/src/main/scala/dev/atedeg/ecscala/util/Event.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/Event.scala
@@ -1,0 +1,40 @@
+package dev.atedeg.ecscala.util
+
+/**
+ * This trait represents an event.
+ * @tparam T
+ *   the type of the parameters that need to be specified when the event is emitted.
+ */
+trait Event[T] {
+
+  /**
+   * When this method is called it represents the event taking place; it will result in executing all the registered
+   * handlers.
+   * @param eventParam
+   *   the parameters that will be passed to all the registered handlers.
+   */
+  def apply(eventParam: T): Unit
+
+  /**
+   * @param handler
+   *   an handler that will be executed when the event takes place.
+   * @return
+   *   a new [[Event]] with the added handler.
+   */
+  def registerHandler(handler: T => Unit): Event[T]
+
+  /**
+   * An alias for [[registerHandler]].
+   */
+  def +(handler: T => Unit) = registerHandler(handler)
+}
+
+object Event {
+  def apply[T](): Event[T] = new EventImpl[T](Seq())
+  private def apply[T](handlers: Seq[T => Unit]): Event[T] = new EventImpl(handlers)
+
+  private class EventImpl[T](private val handlers: Seq[T => Unit]) extends Event[T] {
+    override def apply(eventParam: T): Unit = handlers map (_(eventParam))
+    override def registerHandler(handler: T => Unit): Event[T] = Event(handlers :+ handler)
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -85,9 +85,23 @@ private[ecscala] object ComponentsContainer {
         map filterNot ((e, c) => e == entity && c.eq(component))
       }
 
+      /**
+       * @param entityComponentPair
+       *   the pair to remove.
+       * @return
+       *   an [[Option]] with the map with the removed pair if the map still has some elements; if the removed element
+       *   was the last one and the map would be empty it returns a None.
+       */
       def -?(entityComponentPair: (Entity, T)): Option[Map[Entity, T]] =
         Some(map - entityComponentPair) filter (!_.isEmpty)
 
+      /**
+       * @param entity
+       *   the [[Entity]] to remove.
+       * @return
+       *   an [[Option]] with the map with the removed [[Entity]] if the map still has some elements; if the removed
+       *   element was the last one and the map would be empty it returns a None.
+       */
       def -?(entity: Entity): Option[Map[Entity, T]] = Some(map - entity) filter (!_.isEmpty)
     }
 

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -12,6 +12,7 @@ private[ecscala] trait ComponentsContainer {
   def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
     removeComponent(entityComponentPair)
   def removeEntity(entity: Entity): ComponentsContainer
+  def -(entity: Entity): ComponentsContainer = removeEntity(entity)
 }
 
 private[ecscala] object ComponentsContainer {
@@ -31,11 +32,6 @@ private[ecscala] object ComponentsContainer {
       ComponentsContainer(newComponentsMap)
     }
 
-    /*
-    cc + (e1 -> Position(1,2))
-    cc + (e2 -> Position(2,3))
-    cc - (e2 -> Position(1,2))
-     */
     extension [T <: Component](map: Map[Entity, T]) {
       def -(entityComponentPair: (Entity, T)): Map[Entity, T] = {
         val (entity, component) = entityComponentPair
@@ -57,6 +53,15 @@ private[ecscala] object ComponentsContainer {
       ComponentsContainer(newComponentsMap)
     }
 
-    override def removeEntity(entity: Entity) = ???
+    override def removeEntity(entity: Entity) = {
+//      val newComponentsMap = componentsMap flatMap { (tt, map) =>
+//        val newMap = map - entity
+//        if newMap.isEmpty then None else Some(tt -> newMap)
+//      }
+      val newComponentsMap = componentsMap collect {
+        case (tt, map) if !(map - entity).isEmpty => tt -> (map - entity)
+      }
+      ComponentsContainer(newComponentsMap)
+    }
   }
 }

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -71,6 +71,8 @@ private[ecscala] object ComponentsContainer {
       private val componentsMap: Map[TypeTag[? <: Component], Map[Entity, ? <: Component]] = Map()
   ) extends ComponentsContainer {
     override def apply[T <: Component](using tt: TypeTag[T]) =
+      // This cast is needed to return a map with the appropriate type and not a generic "Component" type.
+      // It is always safe to perform such a cast since the TypeTag holds the type of the retrieved map's components.
       componentsMap.get(tt) map (_.asInstanceOf[Map[Entity, T]])
 
     override def addComponent[T <: Component](entityComponentPair: (Entity, T))(using tt: TypeTag[T]) = {
@@ -82,6 +84,8 @@ private[ecscala] object ComponentsContainer {
     extension [T <: Component](map: Map[Entity, T]) {
       def -(entityComponentPair: (Entity, T)): Map[Entity, T] = {
         val (entity, component) = entityComponentPair
+        // The components are compared using the eq method because, when removing elements, two components are
+        // considered to be equal only if they are the same object.
         map filterNot ((e, c) => e == entity && c.eq(component))
       }
 

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -11,57 +11,54 @@ private[ecscala] trait ComponentsContainer {
 
   /**
    * @tparam T
-   *   the return map's values' type
+   *   the return map's values' type.
    * @return
-   *   A collection of type [[scala.collection.immutable.Map]] [Entity, T]
+   *   a collection of type [[scala.collection.immutable.Map]] [Entity, T].
    */
   def apply[T <: Component: TypeTag]: Option[Map[Entity, T]]
 
   /**
    * @param entityComponentPair
-   *   the (entity, component) pair to add to the container
+   *   the (entity, component) pair to add to the container.
    * @tparam T
-   *   the type of the [[Component]] to add
+   *   the type of the [[Component]] to add.
    * @return
-   *   A new [[ComponentsContainer]] with the added (entity, component) pair
+   *   a new [[ComponentsContainer]] with the added (entity, component) pair.
    */
   def addComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
 
   /**
-   * @see
-   *   [[addComponent]]
+   * An alias for [[addComponent]].
    */
   def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
     addComponent(entityComponentPair)
 
   /**
    * @param entityComponentPair
-   *   the (entity, component) pair to remove from the container
+   *   the (entity, component) pair to remove from the container.
    * @tparam T
-   *   the type of the [[Component]] to remove
+   *   the type of the [[Component]] to remove.
    * @return
-   *   A new [[ComponentsContainer]] with the removed (entity, component) pair
+   *   a new [[ComponentsContainer]] with the removed (entity, component) pair.
    */
   def removeComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
 
   /**
-   * @see
-   *   [[removeComponent]]
+   * An alias for [[removeComponent]].
    */
   def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
     removeComponent(entityComponentPair)
 
   /**
    * @param entity
-   *   the [[Entity]] to remove from the container
+   *   the [[Entity]] to remove from the container.
    * @return
-   *   A [[ComponentsContainer]] with the removed entity and all its components
+   *   a [[ComponentsContainer]] with the removed entity and all its components.
    */
   def removeEntity(entity: Entity): ComponentsContainer
 
   /**
-   * @see
-   *   [[removeEntity]]
+   * An alias for [[removeEntity]].
    */
   def -(entity: Entity): ComponentsContainer = removeEntity(entity)
 }

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -3,15 +3,66 @@ package dev.atedeg.ecscala.util.immutable
 import dev.atedeg.ecscala.{Component, Entity}
 import dev.atedeg.ecscala.util.types.TypeTag
 
+/**
+ * This trait represents a container of multiple [[scala.collection.immutable.Map]] [Entity, T], with T subtype of
+ * Component.
+ */
 private[ecscala] trait ComponentsContainer {
+
+  /**
+   * @tparam T
+   *   the return map's values' type
+   * @return
+   *   A collection of type [[scala.collection.immutable.Map]] [Entity, T]
+   */
   def apply[T <: Component: TypeTag]: Option[Map[Entity, T]]
+
+  /**
+   * @param entityComponentPair
+   *   the (entity, component) pair to add to the container
+   * @tparam T
+   *   the type of the [[Component]] to add
+   * @return
+   *   A new [[ComponentsContainer]] with the added (entity, component) pair
+   */
   def addComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
-  def removeComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
+
+  /**
+   * @see
+   *   [[addComponent]]
+   */
   def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
     addComponent(entityComponentPair)
+
+  /**
+   * @param entityComponentPair
+   *   the (entity, component) pair to remove from the container
+   * @tparam T
+   *   the type of the [[Component]] to remove
+   * @return
+   *   A new [[ComponentsContainer]] with the removed (entity, component) pair
+   */
+  def removeComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
+
+  /**
+   * @see
+   *   [[removeComponent]]
+   */
   def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
     removeComponent(entityComponentPair)
+
+  /**
+   * @param entity
+   *   the [[Entity]] to remove from the container
+   * @return
+   *   A [[ComponentsContainer]] with the removed entity and all its components
+   */
   def removeEntity(entity: Entity): ComponentsContainer
+
+  /**
+   * @see
+   *   [[removeEntity]]
+   */
   def -(entity: Entity): ComponentsContainer = removeEntity(entity)
 }
 

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -1,0 +1,62 @@
+package dev.atedeg.ecscala.util.immutable
+
+import dev.atedeg.ecscala.{Component, Entity}
+import dev.atedeg.ecscala.util.types.TypeTag
+
+private[ecscala] trait ComponentsContainer {
+  def apply[T <: Component: TypeTag]: Option[Map[Entity, T]]
+  def addComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
+  def removeComponent[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer
+  def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
+    addComponent(entityComponentPair)
+  def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): ComponentsContainer =
+    removeComponent(entityComponentPair)
+  def removeEntity(entity: Entity): ComponentsContainer
+}
+
+private[ecscala] object ComponentsContainer {
+  def apply(): ComponentsContainer = new ComponentsContainerImpl
+  private def apply(map: Map[TypeTag[? <: Component], Map[Entity, ? <: Component]]) = new ComponentsContainerImpl(map)
+
+  private class ComponentsContainerImpl(
+      private val componentsMap: Map[TypeTag[? <: Component], Map[Entity, ? <: Component]] = Map()
+  ) extends ComponentsContainer {
+    override def apply[T <: Component](using tt: TypeTag[T]) = componentsMap.get(tt).map(_.asInstanceOf[Map[Entity, T]])
+
+    override def addComponent[T <: Component](entityComponentPair: (Entity, T))(using tt: TypeTag[T]) = {
+      val newComponentsMap = this.apply[T] match {
+        case Some(map) => componentsMap + (tt -> (map + entityComponentPair))
+        case None      => componentsMap + (tt -> Map(entityComponentPair))
+      }
+      ComponentsContainer(newComponentsMap)
+    }
+
+    /*
+    cc + (e1 -> Position(1,2))
+    cc + (e2 -> Position(2,3))
+    cc - (e2 -> Position(1,2))
+     */
+    extension [T <: Component](map: Map[Entity, T]) {
+      def -(entityComponentPair: (Entity, T)): Map[Entity, T] = {
+        val (entity, component) = entityComponentPair
+        map filterNot ((e, c) => e == entity && c.eq(component))
+      }
+    }
+
+    override def removeComponent[T <: Component](entityComponentPair: (Entity, T))(using tt: TypeTag[T]) = {
+      val (entity, component) = entityComponentPair
+      val newComponentsMap = this.apply[T] match {
+        case Some(map) => {
+          (map - entityComponentPair) match {
+            case m if !m.isEmpty => componentsMap + (tt -> m)
+            case _               => componentsMap - tt
+          }
+        }
+        case None => componentsMap
+      }
+      ComponentsContainer(newComponentsMap)
+    }
+
+    override def removeEntity(entity: Entity) = ???
+  }
+}

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -101,7 +101,8 @@ private[ecscala] object ComponentsContainer {
     }
 
     override def removeEntity(entity: Entity) = {
-      val newComponentsMap = componentsMap flatMap { (tt, componentMap) => (componentMap -? entity) map (tt -> _) }
+      val newComponentsMap: Map[TypeTag[? <: Component], Map[Entity, Component]] =
+        componentsMap flatMap { (tt, componentMap) => (componentMap -? entity) map (tt -> _) }
       ComponentsContainer(newComponentsMap)
     }
   }

--- a/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/immutable/ComponentsContainer.scala
@@ -97,8 +97,8 @@ private[ecscala] object ComponentsContainer {
     override def removeComponent[T <: Component](entityComponentPair: (Entity, T))(using tt: TypeTag[T]) = {
       val newComponentsMap =
         this.apply[T] flatMap (_ -? entityComponentPair) match {
-          case Some(m) => componentsMap + (tt -> m)
-          case None    => componentsMap - tt
+          case Some(componentMap) => componentsMap + (tt -> componentMap)
+          case None               => componentsMap - tt
         }
       ComponentsContainer(newComponentsMap)
     }

--- a/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -9,7 +9,7 @@ import scala.quoted.*
  * @tparam T
  *   the type whose compiletime information are stored in the TypeTag.
  */
-private[ecscala] sealed trait TypeTag[T]
+private[ecscala] sealed trait TypeTag[+T]
 
 inline given [T]: TypeTag[T] = ${ deriveTypeTagImpl[T] }
 private def deriveTypeTagImpl[T: Type](using quotes: Quotes): Expr[TypeTag[T]] = {

--- a/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
@@ -104,5 +104,60 @@ class ComponentsContainerTest extends AnyWordSpec with Matchers {
         }
       }
     }
+    "removing an entity" which {
+      "has multiple components" should {
+        "remove all its components" in new WorldFixture with ComponentsFixture {
+          var container = ComponentsContainer()
+          val entity = world.createEntity()
+          container += entity -> Position(1, 2)
+          container += entity -> Velocity(2, 3)
+          container = container.removeEntity(entity)
+          container[Position] match {
+            case Some(m) => fail(m.toString)
+            case None    => ()
+          }
+          container[Velocity] match {
+            case Some(_) => fail()
+            case None    => ()
+          }
+        }
+        "not remove any other entities" in new WorldFixture with ComponentsFixture {
+          var container = ComponentsContainer()
+          val entity1 = world.createEntity()
+          val entity2 = world.createEntity()
+          container += entity1 -> Position(1, 2)
+          container += entity1 -> Velocity(2, 3)
+          container += entity2 -> Position(1, 2)
+          container += entity2 -> Velocity(2, 3)
+          container -= entity1
+          container[Position] match {
+            case Some(map) => map shouldEqual Map(entity2 -> Position(1, 2))
+            case None      => fail()
+          }
+          container[Velocity] match {
+            case Some(map) => map shouldEqual Map(entity2 -> Velocity(2, 3))
+            case None      => fail()
+          }
+        }
+      }
+      "is was not added" should {
+        "not remove anything" in new WorldFixture with ComponentsFixture {
+          var container = ComponentsContainer()
+          val entity1 = world.createEntity()
+          val entity2 = world.createEntity()
+          container += entity1 -> Position(1, 2)
+          container += entity1 -> Velocity(2, 3)
+          container -= entity2
+          container[Position] match {
+            case Some(map) => map shouldEqual Map(entity1 -> Position(1, 2))
+            case None      => fail()
+          }
+          container[Velocity] match {
+            case Some(map) => map shouldEqual Map(entity1 -> Velocity(2, 3))
+            case None      => fail()
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
@@ -1,0 +1,108 @@
+package dev.atedeg.ecscala
+
+import dev.atedeg.ecscala.fixtures.{ComponentsFixture, WorldFixture}
+import dev.atedeg.ecscala.util.types.TypeTag
+import dev.atedeg.ecscala.util.types.{given TypeTag[_]}
+import dev.atedeg.ecscala.util.immutable.ComponentsContainer
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ComponentsContainerTest extends AnyWordSpec with Matchers {
+  "A ComponentsContainer" when {
+    "added an element" which {
+      "was not present" should {
+        "return it with apply" in new WorldFixture with ComponentsFixture {
+          var container = ComponentsContainer()
+          val entity = world.createEntity()
+          container += (entity -> Position(1, 2))
+          container[Position] match {
+            case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
+            case None      => fail()
+          }
+        }
+      }
+      "was present" should {
+        "return the updated version" in new WorldFixture with ComponentsFixture {
+          var container = ComponentsContainer()
+          val entity = world.createEntity()
+          container += (entity -> Position(1, 2))
+          container += (entity -> Position(2, 3))
+          container[Position] match {
+            case Some(map) => map shouldEqual Map(entity -> Position(2, 3))
+            case None      => fail()
+          }
+        }
+      }
+    }
+    "added multiple entities with the same Component type" should {
+      "return a map of all added entities" in new WorldFixture with ComponentsFixture {
+        var container = ComponentsContainer()
+        val entities = (0 until 100) map { _ => world.createEntity() }
+        val entityComponentPairs = entities map (_ -> Position(1, 2))
+        entityComponentPairs foreach (container += _)
+        container[Position] match {
+          case Some(map) => map shouldEqual Map.from(entityComponentPairs)
+          case None      => fail()
+        }
+      }
+    }
+    "removed a component" should {
+      "no longer return it with apply" in new WorldFixture with ComponentsFixture {
+        var container = ComponentsContainer()
+        val entity1 = world.createEntity()
+        val component1 = Position(1, 2)
+        val entity2 = world.createEntity()
+        val component2 = Position(2, 3)
+
+        container += (entity1 -> component1)
+        container += (entity2 -> component2)
+        container -= (entity1 -> component1)
+        container[Position] match {
+          case Some(map) => map shouldEqual Map(entity2 -> component2)
+          case None      => fail()
+        }
+      }
+    }
+    "removed the last component of a type" should {
+      "no longer return a map with apply" in new WorldFixture with ComponentsFixture {
+        var container = ComponentsContainer()
+        val entity = world.createEntity()
+        val component = Position(1, 2)
+        container += (entity -> component)
+        container -= (entity -> component)
+        container[Position] match {
+          case Some(_) => fail()
+          case None    => ()
+        }
+      }
+    }
+    "trying to remove an entity-component pair that does not exist" should {
+      "not remove anything" in new WorldFixture with ComponentsFixture {
+        var container = ComponentsContainer()
+        val entity = world.createEntity()
+        container += entity -> Position(1, 2)
+        container -= entity -> Position(1, 2)
+        container[Position] match {
+          case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
+          case None      => fail()
+        }
+      }
+    }
+    "trying to remove a component of a type that was never added" should {
+      "not remove anything" in new WorldFixture with ComponentsFixture {
+        var container = ComponentsContainer()
+        val entity = world.createEntity()
+        container += entity -> Position(1, 2)
+        container -= entity -> Velocity(1, 2)
+        container[Position] match {
+          case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
+          case None      => fail()
+        }
+        container[Velocity] match {
+          case Some(_) => fail()
+          case None    => ()
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/ComponentsContainerTest.scala
@@ -12,150 +12,119 @@ class ComponentsContainerTest extends AnyWordSpec with Matchers {
     "added an element" which {
       "was not present" should {
         "return it with apply" in new WorldFixture with ComponentsFixture {
-          var container = ComponentsContainer()
           val entity = world.createEntity()
-          container += (entity -> Position(1, 2))
-          container[Position] match {
-            case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
-            case None      => fail()
-          }
+          componentsContainer += (entity -> Position(1, 2))
+
+          componentsContainer[Position] should contain(Map(entity -> Position(1, 2)))
         }
       }
       "was present" should {
         "return the updated version" in new WorldFixture with ComponentsFixture {
-          var container = ComponentsContainer()
           val entity = world.createEntity()
-          container += (entity -> Position(1, 2))
-          container += (entity -> Position(2, 3))
-          container[Position] match {
-            case Some(map) => map shouldEqual Map(entity -> Position(2, 3))
-            case None      => fail()
-          }
+          componentsContainer += (entity -> Position(1, 2))
+          componentsContainer += (entity -> Position(2, 3))
+
+          componentsContainer[Position] should contain(Map(entity -> Position(2, 3)))
         }
       }
     }
     "added multiple entities with the same Component type" should {
       "return a map of all added entities" in new WorldFixture with ComponentsFixture {
-        var container = ComponentsContainer()
-        val entities = (0 until 100) map { _ => world.createEntity() }
+        val entities = (0 until 100) map (_ => world.createEntity())
         val entityComponentPairs = entities map (_ -> Position(1, 2))
-        entityComponentPairs foreach (container += _)
-        container[Position] match {
-          case Some(map) => map shouldEqual Map.from(entityComponentPairs)
-          case None      => fail()
-        }
+        entityComponentPairs foreach (componentsContainer += _)
+
+        componentsContainer[Position] should contain(Map.from(entityComponentPairs))
       }
     }
     "removed a component" should {
       "no longer return it with apply" in new WorldFixture with ComponentsFixture {
-        var container = ComponentsContainer()
         val entity1 = world.createEntity()
         val component1 = Position(1, 2)
         val entity2 = world.createEntity()
-        val component2 = Position(2, 3)
+        componentsContainer += (entity1 -> component1)
+        componentsContainer += (entity2 -> Position(2, 3))
+        componentsContainer -= (entity1 -> component1)
 
-        container += (entity1 -> component1)
-        container += (entity2 -> component2)
-        container -= (entity1 -> component1)
-        container[Position] match {
-          case Some(map) => map shouldEqual Map(entity2 -> component2)
-          case None      => fail()
-        }
+        componentsContainer[Position] should contain(Map(entity2 -> Position(2, 3)))
       }
     }
     "removed the last component of a type" should {
-      "no longer return a map with apply" in new WorldFixture with ComponentsFixture {
-        var container = ComponentsContainer()
+      "no longer return the type's map with apply" in new WorldFixture with ComponentsFixture {
         val entity = world.createEntity()
         val component = Position(1, 2)
-        container += (entity -> component)
-        container -= (entity -> component)
-        container[Position] match {
-          case Some(_) => fail()
-          case None    => ()
-        }
+        componentsContainer += (entity -> component)
+        componentsContainer -= (entity -> component)
+
+        componentsContainer[Position] shouldBe empty
       }
     }
     "trying to remove an entity-component pair that does not exist" should {
       "not remove anything" in new WorldFixture with ComponentsFixture {
-        var container = ComponentsContainer()
-        val entity = world.createEntity()
-        container += entity -> Position(1, 2)
-        container -= entity -> Position(1, 2)
-        container[Position] match {
-          case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
-          case None      => fail()
+        val entity1 = world.createEntity()
+        val component = Position(1, 2)
+        val entity2 = world.createEntity()
+        componentsContainer += entity1 -> component
+        componentsContainer -= entity2 -> component
+
+        componentsContainer[Position] should contain(Map(entity1 -> Position(1, 2)))
+      }
+    }
+    "trying to remove a component" which {
+      "is a case class" should {
+        "remove it only if the references are the same" in new WorldFixture with ComponentsFixture {
+          val entity = world.createEntity()
+          componentsContainer += entity -> Position(1, 2)
+          componentsContainer -= entity -> Position(1, 2)
+
+          componentsContainer[Position] should contain(Map(entity -> Position(1, 2)))
         }
       }
     }
     "trying to remove a component of a type that was never added" should {
       "not remove anything" in new WorldFixture with ComponentsFixture {
-        var container = ComponentsContainer()
         val entity = world.createEntity()
-        container += entity -> Position(1, 2)
-        container -= entity -> Velocity(1, 2)
-        container[Position] match {
-          case Some(map) => map shouldEqual Map(entity -> Position(1, 2))
-          case None      => fail()
-        }
-        container[Velocity] match {
-          case Some(_) => fail()
-          case None    => ()
-        }
+        componentsContainer += entity -> Position(1, 2)
+        componentsContainer -= entity -> Velocity(1, 2)
+
+        componentsContainer[Position] should contain(Map(entity -> Position(1, 2)))
+        componentsContainer[Velocity] shouldBe empty
       }
     }
     "removing an entity" which {
       "has multiple components" should {
         "remove all its components" in new WorldFixture with ComponentsFixture {
-          var container = ComponentsContainer()
           val entity = world.createEntity()
-          container += entity -> Position(1, 2)
-          container += entity -> Velocity(2, 3)
-          container = container.removeEntity(entity)
-          container[Position] match {
-            case Some(m) => fail(m.toString)
-            case None    => ()
-          }
-          container[Velocity] match {
-            case Some(_) => fail()
-            case None    => ()
-          }
+          componentsContainer += entity -> Position(1, 2)
+          componentsContainer += entity -> Velocity(2, 3)
+          componentsContainer -= entity
+
+          componentsContainer[Position] shouldBe empty
+          componentsContainer[Velocity] shouldBe empty
         }
         "not remove any other entities" in new WorldFixture with ComponentsFixture {
-          var container = ComponentsContainer()
           val entity1 = world.createEntity()
           val entity2 = world.createEntity()
-          container += entity1 -> Position(1, 2)
-          container += entity1 -> Velocity(2, 3)
-          container += entity2 -> Position(1, 2)
-          container += entity2 -> Velocity(2, 3)
-          container -= entity1
-          container[Position] match {
-            case Some(map) => map shouldEqual Map(entity2 -> Position(1, 2))
-            case None      => fail()
-          }
-          container[Velocity] match {
-            case Some(map) => map shouldEqual Map(entity2 -> Velocity(2, 3))
-            case None      => fail()
-          }
+          componentsContainer += entity1 -> Position(1, 2)
+          componentsContainer += entity1 -> Velocity(2, 3)
+          componentsContainer += entity2 -> Position(1, 2)
+          componentsContainer += entity2 -> Velocity(2, 3)
+          componentsContainer -= entity1
+
+          componentsContainer[Position] should contain(Map(entity2 -> Position(1, 2)))
+          componentsContainer[Velocity] should contain(Map(entity2 -> Velocity(2, 3)))
         }
       }
-      "is was not added" should {
+      "was not added" should {
         "not remove anything" in new WorldFixture with ComponentsFixture {
-          var container = ComponentsContainer()
           val entity1 = world.createEntity()
           val entity2 = world.createEntity()
-          container += entity1 -> Position(1, 2)
-          container += entity1 -> Velocity(2, 3)
-          container -= entity2
-          container[Position] match {
-            case Some(map) => map shouldEqual Map(entity1 -> Position(1, 2))
-            case None      => fail()
-          }
-          container[Velocity] match {
-            case Some(map) => map shouldEqual Map(entity1 -> Velocity(2, 3))
-            case None      => fail()
-          }
+          componentsContainer += entity1 -> Position(1, 2)
+          componentsContainer += entity1 -> Velocity(2, 3)
+          componentsContainer -= entity2
+
+          componentsContainer[Position] should contain(Map(entity1 -> Position(1, 2)))
+          componentsContainer[Velocity] should contain(Map(entity1 -> Velocity(2, 3)))
         }
       }
     }

--- a/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
@@ -1,6 +1,6 @@
 package dev.atedeg.ecscala
 
-import dev.atedeg.ecscala.fixtures.WorldFixture
+import dev.atedeg.ecscala.fixtures.{ComponentsFixture, WorldFixture}
 import org.scalatest.matchers.should.*
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -10,6 +10,17 @@ class EntityTest extends AnyWordSpec with Matchers {
       "generated from the world" in new WorldFixture {
         val entities = (0 until 1000) map { _ => world.createEntity() }
         entities shouldBe entities.distinct
+      }
+    }
+  }
+  "An Entity" when {
+    "added handlers" should {
+      "execute all of them when a component is added" in new WorldFixture with ComponentsFixture {
+        var n = 0
+        var entity = world.createEntity()
+        (0 until 100) foreach { _ => entity.onAddedComponent(_ => n += 1) }
+        entity addComponent Position(1, 1)
+        n shouldBe 100
       }
     }
   }

--- a/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
@@ -23,6 +23,13 @@ class EntityTest extends AnyWordSpec with Matchers {
         entity addComponent Position(1, 1)
         n shouldBe 100
       }
+      "execute all of them when a component is removed" in new WorldFixture with ComponentsFixture {
+        var n = 0
+        var entity = world.createEntity()
+        (0 until 100) foreach { _ => entity.onRemovedComponent(_ => n += 1) }
+        entity removeComponent Position(1, 1)
+        n shouldBe 100
+      }
     }
   }
 }

--- a/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
@@ -1,6 +1,7 @@
 package dev.atedeg.ecscala
 
 import dev.atedeg.ecscala.fixtures.{ComponentsFixture, WorldFixture}
+import dev.atedeg.ecscala.util.types.given
 import org.scalatest.matchers.should.*
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
@@ -1,6 +1,7 @@
 package dev.atedeg.ecscala
 
-import dev.atedeg.ecscala.fixtures.WorldFixture
+import dev.atedeg.ecscala.fixtures.{ComponentsFixture, WorldFixture}
+import dev.atedeg.ecscala.util.types.TypeTag
 import org.scalatest.matchers.should.*
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -24,6 +25,14 @@ class WorldTest extends AnyWordSpec with Matchers {
           world.removeEntity(entity)
           world.entitiesCount shouldBe 0
         }
+      }
+    }
+    "has entities with components" should {
+      "return the components" in new WorldFixture with ComponentsFixture {
+        import dev.atedeg.ecscala.util.types.{given TypeTag[_]}
+        val entity = world.createEntity()
+        entity addComponent Position(1, 1)
+//        world.getComponents[Position] should contain(Map(entity -> Position(1, 1)))
       }
     }
   }

--- a/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
@@ -35,5 +35,14 @@ class WorldTest extends AnyWordSpec with Matchers {
         world.getComponents[Position] should contain(Map(entity -> Position(1, 1)))
       }
     }
+    "components are removed from its enities" should {
+      "not return the components" in new WorldFixture with ComponentsFixture {
+        val entity = world.createEntity()
+        val component = Position(1, 1)
+        entity addComponent component
+        entity removeComponent component
+        world.getComponents[Position] shouldBe empty
+      }
+    }
   }
 }

--- a/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/WorldTest.scala
@@ -2,6 +2,7 @@ package dev.atedeg.ecscala
 
 import dev.atedeg.ecscala.fixtures.{ComponentsFixture, WorldFixture}
 import dev.atedeg.ecscala.util.types.TypeTag
+import dev.atedeg.ecscala.util.types.given
 import org.scalatest.matchers.should.*
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -29,10 +30,9 @@ class WorldTest extends AnyWordSpec with Matchers {
     }
     "has entities with components" should {
       "return the components" in new WorldFixture with ComponentsFixture {
-        import dev.atedeg.ecscala.util.types.{given TypeTag[_]}
         val entity = world.createEntity()
         entity addComponent Position(1, 1)
-//        world.getComponents[Position] should contain(Map(entity -> Position(1, 1)))
+        world.getComponents[Position] should contain(Map(entity -> Position(1, 1)))
       }
     }
   }

--- a/src/test/scala/dev/atedeg/ecscala/fixtures/ComponentsFixture.scala
+++ b/src/test/scala/dev/atedeg/ecscala/fixtures/ComponentsFixture.scala
@@ -1,8 +1,10 @@
 package dev.atedeg.ecscala.fixtures
 
 import dev.atedeg.ecscala.Component
+import dev.atedeg.ecscala.util.immutable.ComponentsContainer
 
 trait ComponentsFixture {
   case class Position(x: Double, y: Double) extends Component
   case class Velocity(vx: Double, vy: Double) extends Component
+  var componentsContainer: ComponentsContainer = ComponentsContainer()
 }

--- a/src/test/scala/dev/atedeg/ecscala/fixtures/ComponentsFixture.scala
+++ b/src/test/scala/dev/atedeg/ecscala/fixtures/ComponentsFixture.scala
@@ -1,0 +1,8 @@
+package dev.atedeg.ecscala.fixtures
+
+import dev.atedeg.ecscala.Component
+
+trait ComponentsFixture {
+  case class Position(x: Double, y: Double) extends Component
+  case class Velocity(vx: Double, vy: Double) extends Component
+}

--- a/src/test/scala/dev/atedeg/ecscala/util/EventTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/EventTest.scala
@@ -1,0 +1,27 @@
+package dev.atedeg.ecscala.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EventTest extends AnyWordSpec with Matchers {
+  "An Event" when {
+    "added an handler" should {
+      "execute it" in {
+        var executed = false
+        var event = Event[Boolean]()
+        event += (executed = _)
+        event(true)
+        executed shouldBe true
+      }
+    }
+    "added multiple handlers" should {
+      "executed all of them" in {
+        var n = 0
+        var event = Event[Int]()
+        (0 until 100) foreach (_ => event += (n += _))
+        event(1)
+        n shouldBe 100
+      }
+    }
+  }
+}

--- a/src/test/scala/dev/atedeg/ecscala/util/EventTest.scala
+++ b/src/test/scala/dev/atedeg/ecscala/util/EventTest.scala
@@ -23,5 +23,31 @@ class EventTest extends AnyWordSpec with Matchers {
         n shouldBe 100
       }
     }
+    "removed an handler" should {
+      "return a new Event without it" in {
+        var s = ""
+        var event = Event[String]()
+        val handler: String => Unit = (s += _)
+        event += handler
+        event -= handler
+        event("Test")
+        s shouldBe ""
+      }
+    }
+    "removed an handler" should {
+      "still execute the others" in {
+        var n = 0
+        var event = Event[Int]()
+        val handler: Int => Unit = (n += _)
+        val handler2: Int => Unit = (n += _)
+        event += handler
+        event += handler2
+        event -= handler2
+        event(1)
+        event(1)
+        n shouldBe 2
+      }
+    }
+
   }
 }


### PR DESCRIPTION
This PR introduces a first implementation of the `World` and `Component` traits.
It also implements a `TypeTag` trait which is used to perform runtime checks on the compile time type of the components.
Lastly, implements a `ComponentsContainer` which is used to store maps from an Entity to Components of a specific type.

Closes #34 
Closes #35 
Closes #36