### PR TITLE
TypeTag refactor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,7 @@ lazy val core = project
       formats = Seq(JacocoReportFormats.HTML, JacocoReportFormats.XML),
       fileEncoding = "utf-8",
     ),
-    Test / jacocoExcludes := Seq("**.macros.*"),
+    Test / jacocoExcludes := Seq("**.macros.*", "**.types.*"),
   )
 
 lazy val benchmarks = project

--- a/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -42,13 +42,13 @@ object Entity {
 
     override def addComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(Some(this))
-      world.componentAdded(this, component)
+      world + (this -> component)
       this
     }
 
     override def removeComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(None)
-      world.componentRemoved(this, component)
+      world - (this -> component)
       this
     }
   }

--- a/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -42,13 +42,13 @@ object Entity {
 
     override def addComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(Some(this))
-      world + (this -> component)
+      world += (this -> component)
       this
     }
 
     override def removeComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(None)
-      world - (this -> component)
+      world -= (this -> component)
       this
     }
   }

--- a/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/Entity.scala
@@ -28,22 +28,6 @@ sealed trait Entity {
    *   itself.
    */
   def removeComponent[T <: Component: TypeTag](component: T): Entity
-
-  /**
-   * @param handler
-   *   the handler to execute when a [[Component]] is added to this entity.
-   * @return
-   *   itself.
-   */
-  private[ecscala] def onAddedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit): Entity
-
-  /**
-   * @param handler
-   *   the handler to execute when a [[Component]] is removed from this entity.
-   * @return
-   *   itself.
-   */
-  private[ecscala] def onRemovedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit): Entity
 }
 
 /**
@@ -52,31 +36,19 @@ sealed trait Entity {
 object Entity {
   opaque private type Id = Int
 
-  protected[ecscala] def apply(): Entity = EntityImpl(IdGenerator.nextId())
+  protected[ecscala] def apply(world: World): Entity = EntityImpl(IdGenerator.nextId(), world)
 
-  private case class EntityImpl(private val id: Id) extends Entity {
-    private var onAddedComponentEvent: Event[(Entity, TypeTag[Component], Component)] = Event()
-    private var onRemovedComponentEvent: Event[(Entity, TypeTag[Component], Component)] = Event()
+  private case class EntityImpl(private val id: Id, private val world: World) extends Entity {
 
     override def addComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(Some(this))
-      onAddedComponentEvent(this, tt, component)
-      this
-    }
-
-    override def onAddedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit): Entity = {
-      onAddedComponentEvent += handler
+      world.componentAdded(this, component)
       this
     }
 
     override def removeComponent[T <: Component](component: T)(using tt: TypeTag[T]): Entity = {
       component.setEntity(None)
-      onRemovedComponentEvent(this, tt, component)
-      this
-    }
-
-    private[ecscala] override def onRemovedComponent(handler: ((Entity, TypeTag[Component], Component)) => Unit) = {
-      onRemovedComponentEvent += handler
+      world.componentRemoved(this, component)
       this
     }
   }

--- a/core/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -1,5 +1,6 @@
 package dev.atedeg.ecscala
 
+import scala.annotation.targetName
 import dev.atedeg.ecscala.util.immutable.ComponentsContainer
 import dev.atedeg.ecscala.util.types.TypeTag
 
@@ -30,8 +31,12 @@ trait World {
   def removeEntity(entity: Entity): Unit
 
   private[ecscala] def getComponents[T <: Component: TypeTag]: Option[Map[Entity, T]]
-  private[ecscala] def componentAdded[T <: Component: TypeTag](entity: Entity, component: T): Unit
-  private[ecscala] def componentRemoved[T <: Component: TypeTag](entity: Entity, component: T): Unit
+
+  @targetName("addComponent")
+  private[ecscala] def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit
+
+  @targetName("removeComponent")
+  private[ecscala] def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit
 }
 
 /**
@@ -66,10 +71,12 @@ object World {
     private[ecscala] override def getComponents[T <: Component: TypeTag] =
       componentsContainer[T]
 
-    private[ecscala] override def componentAdded[T <: Component: TypeTag](entity: Entity, component: T): Unit =
-      componentsContainer += (entity, component)
+    @targetName("addComponent")
+    private[ecscala] override def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit =
+      componentsContainer += entityComponentPair
 
-    private[ecscala] override def componentRemoved[T <: Component: TypeTag](entity: Entity, component: T): Unit =
-      componentsContainer -= (entity, component)
+    @targetName("removeComponent")
+    private[ecscala] override def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit =
+      componentsContainer -= entityComponentPair
   }
 }

--- a/core/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -33,10 +33,10 @@ trait World {
   private[ecscala] def getComponents[T <: Component: TypeTag]: Option[Map[Entity, T]]
 
   @targetName("addComponent")
-  private[ecscala] def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit
+  private[ecscala] def +=[T <: Component: TypeTag](entityComponentPair: (Entity, T)): World
 
   @targetName("removeComponent")
-  private[ecscala] def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit
+  private[ecscala] def -=[T <: Component: TypeTag](entityComponentPair: (Entity, T)): World
 }
 
 /**
@@ -72,11 +72,15 @@ object World {
       componentsContainer[T]
 
     @targetName("addComponent")
-    private[ecscala] override def +[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit =
+    private[ecscala] override def +=[T <: Component: TypeTag](entityComponentPair: (Entity, T)): World = {
       componentsContainer += entityComponentPair
+      this
+    }
 
     @targetName("removeComponent")
-    private[ecscala] override def -[T <: Component: TypeTag](entityComponentPair: (Entity, T)): Unit =
+    private[ecscala] override def -=[T <: Component: TypeTag](entityComponentPair: (Entity, T)): World = {
       componentsContainer -= entityComponentPair
+      this
+    }
   }
 }

--- a/core/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -30,6 +30,8 @@ trait World {
   def removeEntity(entity: Entity): Unit
 
   private[ecscala] def getComponents[T <: Component: TypeTag]: Option[Map[Entity, T]]
+  private[ecscala] def componentAdded[T <: Component: TypeTag](entity: Entity, component: T): Unit
+  private[ecscala] def componentRemoved[T <: Component: TypeTag](entity: Entity, component: T): Unit
 }
 
 /**
@@ -51,11 +53,7 @@ object World {
     override def entitiesCount: Int = entities.size
 
     override def createEntity(): Entity = {
-      val entity = Entity()
-      entity.onAddedComponent((e, tt, c) => (componentsContainer = componentsContainer.addComponent(e, c)(using tt)))
-      entity.onRemovedComponent((e, tt, c) =>
-        (componentsContainer = componentsContainer.removeComponent(e, c)(using tt)),
-      )
+      val entity = Entity(this)
       entities += entity
       entity
     }
@@ -65,6 +63,13 @@ object World {
       componentsContainer -= entity
     }
 
-    private[ecscala] override def getComponents[T <: Component: TypeTag] = componentsContainer[T]
+    private[ecscala] override def getComponents[T <: Component: TypeTag] =
+      componentsContainer[T]
+
+    private[ecscala] override def componentAdded[T <: Component: TypeTag](entity: Entity, component: T): Unit =
+      componentsContainer += (entity, component)
+
+    private[ecscala] override def componentRemoved[T <: Component: TypeTag](entity: Entity, component: T): Unit =
+      componentsContainer -= (entity, component)
   }
 }

--- a/core/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/util/types/TypeTag.scala
@@ -20,7 +20,7 @@ private def deriveTypeTagImpl[T: Type](using quotes: Quotes): Expr[TypeTag[T]] =
   val typeReprOfT = TypeRepr.of[T]
   if typeReprOfT =:= TypeRepr.of[Component] then
     report.error("Can only derive TypeTags for subtypes of Component, not for Component itself.")
-  else if typeReprOfT =:= TypeRepr.of[Nothing] then report.error("Can not derive TypeTag[Nothing]")
+  else if typeReprOfT =:= TypeRepr.of[Nothing] then report.error("Cannot derive TypeTag[Nothing]")
   else if !(typeReprOfT <:< TypeRepr.of[Component]) then
     report.error(s"${typeReprOfT.show} must be a subtype of Component")
 

--- a/core/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
+++ b/core/src/test/scala/dev/atedeg/ecscala/EntityTest.scala
@@ -15,23 +15,4 @@ class EntityTest extends AnyWordSpec with Matchers {
       }
     }
   }
-
-  "An Entity" when {
-    "added handlers" should {
-      "execute all of them when a component is added" in new WorldFixture with ComponentsFixture {
-        var n = 0
-        var entity = world.createEntity()
-        (0 until 100) foreach { _ => entity.onAddedComponent(_ => n += 1) }
-        entity addComponent Position(1, 1)
-        n shouldBe 100
-      }
-      "execute all of them when a component is removed" in new WorldFixture with ComponentsFixture {
-        var n = 0
-        var entity = world.createEntity()
-        (0 until 100) foreach { _ => entity.onRemovedComponent(_ => n += 1) }
-        entity removeComponent Position(1, 1)
-        n shouldBe 100
-      }
-    }
-  }
 }

--- a/core/src/test/scala/dev/atedeg/ecscala/util/types/TypeTagTest.scala
+++ b/core/src/test/scala/dev/atedeg/ecscala/util/types/TypeTagTest.scala
@@ -2,8 +2,14 @@ package dev.atedeg.ecscala.util.types
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import dev.atedeg.ecscala.fixtures.ComponentsFixture
 
 class TypeTagTest extends AnyWordSpec with Matchers {
+
+  "A TypeTag[Position]" should new ComponentsFixture {
+    "be equal to TypeTag[Position]" in assertTagsEqual[Position, Position]
+    "not be equal to TypeTag[Velocity]" in assertTagsNotEqual[Position, Velocity]
+  }
 
   def assertTagsEqual[A, B](using ttA: TypeTag[A], ttB: TypeTag[B]): Unit = {
     ttA shouldEqual ttB
@@ -15,15 +21,17 @@ class TypeTagTest extends AnyWordSpec with Matchers {
     ttB should not equal ttA
   }
 
-  "A TypeTag[Int]" should {
-    "be equal to TypeTag[Int]" in assertTagsEqual[Int, Int]
-    "not be equal to TypeTag[String]" in assertTagsNotEqual[Int, String]
-    "not be equal to TypeTag[Any]" in assertTagsNotEqual[Int, Any]
+  "The compiler" should {
+    "not derive a TypeTag[List[Position]]" in assertTypeTagIsNotDerived("List[Position]")
+    "not derive a TypeTag[Nothing]" in assertTypeTagIsNotDerived("Nothing")
+    "not derive a TypeTag[Component]" in assertTypeTagIsNotDerived("Component")
+    "derive a TypeTag[Position]" in assertTypeTagIsDerived("Position")
+    "derive a TypeTag[Velocity]" in assertTypeTagIsDerived("Velocity")
   }
 
-  "A TypeTag[List[Int]]" should {
-    "be equal to TypeTag[List[Int]]" in assertTagsEqual[List[Int], List[Int]]
-    "not be equal to TypeTag[List[String]]" in assertTagsNotEqual[List[Int], List[String]]
-    "not be equal to TypeTag[List[Any]]" in assertTagsNotEqual[List[Int], List[Any]]
-  }
+  inline def assertTypeTagIsNotDerived(inline tagType: String): ComponentsFixture =
+    new ComponentsFixture { "summon[TypeTag[" + tagType + "]]" shouldNot typeCheck }
+
+  inline def assertTypeTagIsDerived(inline tagType: String): ComponentsFixture =
+    new ComponentsFixture { "summon[TypeTag[" + tagType + "]]" should compile }
 }


### PR DESCRIPTION
This PR introduces some changes in TypeTags:
- I removed TypeTag covariance since it would mess up with the correct inference of the type T
- I added more compile-time checks in order to ensure that the compiler will only derive TypeTag instances for components
- I tested the aforementioned changes
- I removed the Events in entities, despite being a good idea it would greatly increase the difficulty of finding an elegant implementation for handling the list of event handlers