### PR TITLE
Further checks on CListTags

### DIFF
--- a/core/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -2,7 +2,6 @@ package dev.atedeg.ecscala
 
 import scala.annotation.targetName
 import dev.atedeg.ecscala.util.immutable.ComponentsContainer
-import dev.atedeg.ecscala.util.macros.ViewMacro.createViewImpl
 import dev.atedeg.ecscala.util.types.{ CListTag, ComponentTag }
 
 /**

--- a/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
@@ -1,9 +1,9 @@
 package dev.atedeg.ecscala.util.types
 
-import dev.atedeg.ecscala.{ &:, CList, Component }
-import dev.atedeg.ecscala.util.types.given
+import dev.atedeg.ecscala.{ &:, CList, CNil, Component }
+import dev.atedeg.ecscala.util.types
 
-import scala.compiletime.{ codeOf, erasedValue, error }
+import scala.compiletime.erasedValue
 import scala.annotation.tailrec
 import scala.quoted.{ Expr, Quotes, Type }
 
@@ -11,16 +11,28 @@ sealed trait CListTag[L <: CList] {
   def tags: Seq[ComponentTag[? <: Component]]
 }
 
-inline given [L <: CList]: CListTag[L] = {
-  inline if containsDuplicates[L] then error("A CListTag cannot be generated for CLists with duplicate element types.")
+inline given [L <: CList]: CListTag[L] = ${ deriveCListTagImpl[L] }
 
-  new CListTag[L] {
-    override def tags = getTags[L]
-    override def toString: String = tags.toString
-    override def hashCode: Int = tags.hashCode
-    override def equals(obj: Any) = obj match {
-      case that: CListTag[_] => that.tags == this.tags
-      case _ => false
+private def deriveCListTagImpl[L <: CList: Type](using quotes: Quotes): Expr[CListTag[L]] = {
+  import quotes.reflect.*
+  val typeReprOfL = TypeRepr.of[L]
+  if typeReprOfL =:= TypeRepr.of[Nothing] then report.error("Cannot derive CListTag for Nothing.")
+  else if typeReprOfL =:= TypeRepr.of[CList] then
+    report.error("Cannot derive CListTag for a generic CList, its exact components must be known at compile time.")
+  else if typeReprOfL =:= TypeRepr.of[CNil] then
+    report.error("Cannot derive CListTag for a CNil, it must have at least one Component.")
+  else if containsDuplicates[L] then
+    report.error("A CListTag cannot be derived from CLists with duplicate element types.")
+
+  '{
+    new CListTag[L] {
+      override def tags = getTags[L]
+      override def toString: String = tags.toString
+      override def hashCode: Int = tags.hashCode
+      override def equals(obj: Any) = obj match {
+        case that: CListTag[_] => that.tags == this.tags
+        case _ => false
+      }
     }
   }
 }
@@ -32,15 +44,15 @@ inline private def getTags[L <: CList]: Seq[ComponentTag[? <: Component]] = {
   }
 }
 
-inline private def containsDuplicates[L <: CList]: Boolean =
-  inline erasedValue[L] match {
-    case _: (head &: tail) => countRepetitions[L, head] > 1 || containsDuplicates[tail]
+private def containsDuplicates[L <: CList: Type](using quotes: Quotes): Boolean =
+  Type.of[L] match {
+    case '[head &: tail] => countRepetitions[L, head] > 1 || containsDuplicates[tail]
     case _ => false
   }
 
-inline private def countRepetitions[L <: CList, C <: Component]: Int =
-  inline erasedValue[L] match {
-    case _: (C &: tail) => 1 + countRepetitions[tail, C]
-    case _: (_ &: tail) => countRepetitions[tail, C]
+private def countRepetitions[L <: CList: Type, C <: Component: Type](using quotes: Quotes): Int =
+  Type.of[L] match {
+    case '[C &: tail] => 1 + countRepetitions[tail, C]
+    case '[_ &: tail] => countRepetitions[tail, C]
     case _ => 0
   }

--- a/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
@@ -3,6 +3,8 @@ package dev.atedeg.ecscala.util.types
 import dev.atedeg.ecscala.{ &:, CList, Component }
 import dev.atedeg.ecscala.util.types.given
 
+import scala.compiletime.{ codeOf, erasedValue, error }
+import scala.annotation.tailrec
 import scala.quoted.{ Expr, Quotes, Type }
 
 sealed trait CListTag[L <: CList] {
@@ -10,6 +12,8 @@ sealed trait CListTag[L <: CList] {
 }
 
 inline given [L <: CList]: CListTag[L] = {
+  inline if containsDuplicates[L] then error("A CListTag cannot be generated for CLists with duplicate element types.")
+
   new CListTag[L] {
     override def tags = getTags[L]
     override def toString: String = tags.toString
@@ -22,9 +26,21 @@ inline given [L <: CList]: CListTag[L] = {
 }
 
 inline private def getTags[L <: CList]: Seq[ComponentTag[? <: Component]] = {
-  import scala.compiletime.erasedValue
   inline erasedValue[L] match {
     case _: (head &: tail) => summon[ComponentTag[head]] +: getTags[tail]
     case _ => Seq()
   }
 }
+
+inline private def containsDuplicates[L <: CList]: Boolean =
+  inline erasedValue[L] match {
+    case _: (head &: tail) => countRepetitions[L, head] > 1 || containsDuplicates[tail]
+    case _ => false
+  }
+
+inline private def countRepetitions[L <: CList, C <: Component]: Int =
+  inline erasedValue[L] match {
+    case _: (C &: tail) => 1 + countRepetitions[tail, C]
+    case _: (_ &: tail) => countRepetitions[tail, C]
+    case _ => 0
+  }

--- a/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/util/types/CListTag.scala
@@ -3,8 +3,6 @@ package dev.atedeg.ecscala.util.types
 import dev.atedeg.ecscala.{ &:, CList, CNil, Component }
 import dev.atedeg.ecscala.util.types
 
-import scala.compiletime.erasedValue
-import scala.annotation.tailrec
 import scala.quoted.{ Expr, Quotes, Type }
 
 sealed trait CListTag[L <: CList] {
@@ -38,6 +36,7 @@ private def deriveCListTagImpl[L <: CList: Type](using quotes: Quotes): Expr[CLi
 }
 
 inline private def getTags[L <: CList]: Seq[ComponentTag[? <: Component]] = {
+  import scala.compiletime.erasedValue
   inline erasedValue[L] match {
     case _: (head &: tail) => summon[ComponentTag[head]] +: getTags[tail]
     case _ => Seq()

--- a/core/src/main/scala/dev/atedeg/ecscala/util/types/ComponentTag.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/util/types/ComponentTag.scala
@@ -2,7 +2,7 @@ package dev.atedeg.ecscala.util.types
 
 import dev.atedeg.ecscala.{ CList, Component }
 
-import scala.quoted.*
+import scala.quoted.{ Expr, Quotes, Type }
 
 /**
  * A ComponentTag is a trait used to describe types keeping information about the type that would otherwise be erased at

--- a/core/src/test/scala/dev/atedeg/ecscala/util/types/CListTagTest.scala
+++ b/core/src/test/scala/dev/atedeg/ecscala/util/types/CListTagTest.scala
@@ -2,23 +2,30 @@ package dev.atedeg.ecscala.util.types
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import dev.atedeg.ecscala.{ &:, CNil }
-import dev.atedeg.ecscala.fixtures.{ Position, Velocity }
+import dev.atedeg.ecscala.{ &:, CList, CNil }
+import dev.atedeg.ecscala.fixtures.{ ComponentsFixture, Position, Velocity }
 
 class CListTagTest extends AnyWordSpec with Matchers {
 
-  "A CListTag" when {
-    "has type CNil" should {
-      "have no tags" in {
-        summon[CListTag[CNil]].tags shouldBe empty
-      }
-    }
-    "has a CList" should {
-      "have the appropriate tags" in {
-        summon[CListTag[Position &: CNil]].tags shouldBe Seq(summon[ComponentTag[Position]])
-        summon[CListTag[Position &: Velocity &: CNil]].tags shouldBe
-          Seq(summon[ComponentTag[Position]], summon[ComponentTag[Velocity]])
-      }
+  "A CListTag" should {
+    "have the correct components" in {
+      summon[CListTag[Position &: CNil]].tags shouldBe Seq(summon[ComponentTag[Position]])
+      summon[CListTag[Position &: Velocity &: CNil]].tags shouldBe
+        Seq(summon[ComponentTag[Position]], summon[ComponentTag[Velocity]])
     }
   }
+
+  "The compiler" should {
+    "not derive a CListTag[Nothing]" in assertCListTagIsNotDerived("Nothing")
+    "not derive a CListTag[CNil]" in assertCListTagIsNotDerived("CNil")
+    "not derive a CListTag[CList]" in assertCListTagIsNotDerived("CList")
+    "not derive a CListTag with duplicates" in assertCListTagIsNotDerived("Velocity &: Position &: Position &: CNil")
+    "derive a correct CListTag" in assertCListTagIsDerived("Velocity &: Position &: CNil")
+  }
+
+  inline def assertCListTagIsNotDerived(inline tagType: String): ComponentsFixture =
+    new ComponentsFixture { "summon[CListTag[" + tagType + "]]" shouldNot typeCheck }
+
+  inline def assertCListTagIsDerived(inline tagType: String): ComponentsFixture =
+    new ComponentsFixture { "summon[CListTag[" + tagType + "]]" should compile }
 }


### PR DESCRIPTION
This PR adds more compile time checks on CList, ensuring that programs that misuse CListTags will not even compile.