### PR TITLE
Coverage improvements

### DIFF
--- a/core/src/main/scala/dev/atedeg/ecscala/World.scala
+++ b/core/src/main/scala/dev/atedeg/ecscala/World.scala
@@ -152,51 +152,5 @@ object World {
       componentsContainer -= entityComponentPair
       this
     }
-
-    private def convertFunctionToSystem[L <: CList](
-        system: (Entity, L, DeltaTime) => Deletable[L],
-    )(using clt: CListTag[L]): System[L] =
-      new System[L](using clt) {
-
-        override def update(
-            entity: Entity,
-            components: L,
-        )(deltaTime: DeltaTime, world: World, view: View[L]): Deletable[L] = system(entity, components, deltaTime)
-      }
-
-    private def convertFunctionToSystem[L <: CList](
-        system: (Entity, L, DeltaTime, World, View[L]) => Deletable[L],
-    )(using clt: CListTag[L]): System[L] = new System[L](using clt) {
-
-      override def update(
-          entity: Entity,
-          components: L,
-      )(deltaTime: DeltaTime, world: World, view: View[L]): Deletable[L] =
-        system(entity, components, deltaTime, world, view)
-    }
-
-    private def convertFunctionToSystem[LIncluded <: CList, LExcluded <: CList](
-        system: (Entity, LIncluded, DeltaTime) => Deletable[LIncluded],
-    )(using cltIncl: CListTag[LIncluded], cltExcl: CListTag[LExcluded]): ExcludingSystem[LIncluded, LExcluded] =
-      new ExcludingSystem[LIncluded, LExcluded](using cltIncl, cltExcl) {
-
-        override def update(
-            entity: Entity,
-            components: LIncluded,
-        )(deltaTime: DeltaTime, world: World, view: View[LIncluded]): Deletable[LIncluded] =
-          system(entity, components, deltaTime)
-      }
-
-    private def convertFunctionToSystem[LIncluded <: CList, LExcluded <: CList](
-        system: (Entity, LIncluded, DeltaTime, World, View[LIncluded]) => Deletable[LIncluded],
-    )(using cltIncl: CListTag[LIncluded], cltExcl: CListTag[LExcluded]): ExcludingSystem[LIncluded, LExcluded] =
-      new ExcludingSystem[LIncluded, LExcluded] {
-
-        override def update(
-            entity: Entity,
-            components: LIncluded,
-        )(deltaTime: DeltaTime, world: World, view: View[LIncluded]): Deletable[LIncluded] =
-          system(entity, components, deltaTime, world, view)
-      }
   }
 }

--- a/core/src/test/scala/dev/atedeg/ecscala/SystemTest.scala
+++ b/core/src/test/scala/dev/atedeg/ecscala/SystemTest.scala
@@ -130,8 +130,9 @@ class SystemTest extends AnyWordSpec with Matchers {
       "not run its update" in new ViewFixture {
         var updateExecuted = false
         world.addSystem(
-          System[Position &: CNil].excluding[Position &: CNil]
-            .withUpdate { (_, cs, _) => updateExecuted = true; cs }
+          System[Position &: CNil].excluding[Position &: CNil].withUpdate { (_, cs, _) =>
+            updateExecuted = true; cs
+          },
         )
         updateExecuted shouldBe false
       }
@@ -144,6 +145,12 @@ class SystemTest extends AnyWordSpec with Matchers {
       world.addSystem(System.empty((_, _) => success = true))
       world.update(10)
       success shouldBe true
+    }
+    "throw an exception" when {
+      "calling the wrong update" in new ViewFixture {
+        an[IllegalStateException] should be thrownBy
+          EmptySystem((_, _) => ()).update(entity1, CNil)(10, world, world.getView[CNil])
+      }
     }
   }
 }

--- a/core/src/test/scala/dev/atedeg/ecscala/SystemTest.scala
+++ b/core/src/test/scala/dev/atedeg/ecscala/SystemTest.scala
@@ -114,7 +114,7 @@ class SystemTest extends AnyWordSpec with Matchers {
   "An ExcludingSystem" when {
     "executing its update" should beAbleTo {
       "update components" in new ViewFixture {
-        world.addSystem(ExcludingSystem[Position &: Velocity &: CNil, Mass &: CNil]((_, comps, _) => {
+        world.addSystem(ExcludingSystem[Position &: Velocity &: CNil, Mass &: CNil]((_, comps, _, _, _) => {
           val Position(x, y) &: Velocity(vx, vy) &: CNil = comps
           Position(x + 1, y + 1) &: Velocity(vx + 1, vy + 1) &: CNil
         }))
@@ -124,6 +124,16 @@ class SystemTest extends AnyWordSpec with Matchers {
           (entity1, Position(2, 2) &: Velocity(2, 2)),
           (entity4, Position(2, 2) &: Velocity(2, 2)),
         )
+      }
+    }
+    "excludes included components" should {
+      "not run its update" in new ViewFixture {
+        var updateExecuted = false
+        world.addSystem(
+          System[Position &: CNil].excluding[Position &: CNil]
+            .withUpdate { (_, cs, _) => updateExecuted = true; cs }
+        )
+        updateExecuted shouldBe false
       }
     }
   }


### PR DESCRIPTION
This PR removes some unused methods that were making the coverage artificially low; moreover, a test was added to `EmptySystemTest` to cover a piece of code that was not tested 